### PR TITLE
Move to .NET 6: update framework, dependencies and code. Increase major version to 2.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -122,6 +122,8 @@ csharp_using_directive_placement = inside_namespace:warning # Add 'using' direct
 
 #### C# Formatting Rules ####
 
+csharp_style_namespace_declarations = file_scoped:warning
+
 # New line preferences
 csharp_new_line_before_catch = true
 csharp_new_line_before_else = true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,17 +21,17 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2.1.0
+      with:
+        dotnet-version: 6.0.x
+
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.6
 
     - name: Restore dependencies
       run: nuget restore $SOLUTION
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-
+      
     - name: Build
       run: dotnet build $SOLUTION --configuration $BUILD_CONFIG --no-restore
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       run: nuget restore $SOLUTION
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2.1.0
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,12 @@ on:
     - main
     
 jobs:
-  build:
+  build-deploy:
 
     env:
       BUILD_CONFIG: 'Release'
       SOLUTION: 'ToolPack.Exceptions.sln'
+      PUSH_PACKAGES: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
     runs-on: ubuntu-latest
 
@@ -21,15 +22,15 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
+      uses: NuGet/setup-nuget@v1.0.6
 
     - name: Restore dependencies
       run: nuget restore $SOLUTION
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v2.1.0
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Build
       run: dotnet build $SOLUTION --configuration $BUILD_CONFIG --no-restore
@@ -38,7 +39,9 @@ jobs:
       run: dotnet test --verbosity normal
 
     - name: Pack
+      if: ${{ env.PUSH_PACKAGES }}
       run: dotnet pack $SOLUTION --configuration $BUILD_CONFIG --no-restore
 
     - name: Publish
+      if: ${{ env.PUSH_PACKAGES }}
       run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_NUNOHPINHEIRO}}

--- a/samples/GrpcAPI/GrpcAPI.csproj
+++ b/samples/GrpcAPI/GrpcAPI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.46.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GrpcAPI/JustAnInterceptor.cs
+++ b/samples/GrpcAPI/JustAnInterceptor.cs
@@ -1,56 +1,55 @@
-namespace GrpcAPI
+namespace GrpcAPI;
+
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+public class JustAnInterceptor : Interceptor
 {
-    using Grpc.Core;
-    using Grpc.Core.Interceptors;
-    using Microsoft.Extensions.Logging;
-    using System.Threading.Tasks;
+    private readonly ILogger<JustAnInterceptor> _logger;
 
-    public class JustAnInterceptor : Interceptor
+    public JustAnInterceptor(
+        ILogger<JustAnInterceptor> logger)
     {
-        private readonly ILogger<JustAnInterceptor> _logger;
+        _logger = logger;
+    }
 
-        public JustAnInterceptor(
-            ILogger<JustAnInterceptor> logger)
-        {
-            _logger = logger;
-        }
+    public async override Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        ServerCallContext context,
+        ClientStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("JUST AN INTERCEPTOR - client streaming server handler.");
+        return await continuation(requestStream, context);
+    }
 
-        public async override Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
-            IAsyncStreamReader<TRequest> requestStream,
-            ServerCallContext context,
-            ClientStreamingServerMethod<TRequest, TResponse> continuation)
-        {
-            _logger.LogInformation("JUST AN INTERCEPTOR - client streaming server handler.");
-            return await continuation(requestStream, context);
-        }
+    public async override Task DuplexStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("JUST AN INTERCEPTOR - duplex streaming server handler.");
+        await continuation(requestStream, responseStream, context);
+    }
 
-        public async override Task DuplexStreamingServerHandler<TRequest, TResponse>(
-            IAsyncStreamReader<TRequest> requestStream,
-            IServerStreamWriter<TResponse> responseStream,
-            ServerCallContext context,
-            DuplexStreamingServerMethod<TRequest, TResponse> continuation)
-        {
-            _logger.LogInformation("JUST AN INTERCEPTOR - duplex streaming server handler.");
-            await continuation(requestStream, responseStream, context);
-        }
+    public async override Task ServerStreamingServerHandler<TRequest, TResponse>(
+        TRequest request,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        ServerStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("JUST AN INTERCEPTOR - server streaming server handler.");
+        await continuation(request, responseStream, context);
+    }
 
-        public async override Task ServerStreamingServerHandler<TRequest, TResponse>(
-            TRequest request,
-            IServerStreamWriter<TResponse> responseStream,
-            ServerCallContext context,
-            ServerStreamingServerMethod<TRequest, TResponse> continuation)
-        {
-            _logger.LogInformation("JUST AN INTERCEPTOR - server streaming server handler.");
-            await continuation(request, responseStream, context);
-        }
-
-        public async override Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
-            TRequest request,
-            ServerCallContext context,
-            UnaryServerMethod<TRequest, TResponse> continuation)
-        {
-            _logger.LogInformation("JUST AN INTERCEPTOR - unary server handler.");
-            return await continuation(request, context);
-        }
+    public async override Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("JUST AN INTERCEPTOR - unary server handler.");
+        return await continuation(request, context);
     }
 }

--- a/samples/GrpcAPI/JustAnotherInterceptor.cs
+++ b/samples/GrpcAPI/JustAnotherInterceptor.cs
@@ -1,56 +1,55 @@
-namespace GrpcAPI
+namespace GrpcAPI;
+
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+public class JustAnotherInterceptor : Interceptor
 {
-    using Grpc.Core;
-    using Grpc.Core.Interceptors;
-    using Microsoft.Extensions.Logging;
-    using System.Threading.Tasks;
+    private readonly ILogger<JustAnotherInterceptor> _logger;
 
-    public class JustAnotherInterceptor : Interceptor
+    public JustAnotherInterceptor(
+        ILogger<JustAnotherInterceptor> logger)
     {
-        private readonly ILogger<JustAnotherInterceptor> _logger;
+        _logger = logger;
+    }
 
-        public JustAnotherInterceptor(
-            ILogger<JustAnotherInterceptor> logger)
-        {
-            _logger = logger;
-        }
+    public async override Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        ServerCallContext context,
+        ClientStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("JUST ANOTHER INTERCEPTOR - client streaming server handler.");
+        return await continuation(requestStream, context);
+    }
 
-        public async override Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
-            IAsyncStreamReader<TRequest> requestStream,
-            ServerCallContext context,
-            ClientStreamingServerMethod<TRequest, TResponse> continuation)
-        {
-            _logger.LogInformation("JUST ANOTHER INTERCEPTOR - client streaming server handler.");
-            return await continuation(requestStream, context);
-        }
+    public async override Task DuplexStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("JUST ANOTHER INTERCEPTOR - duplex streaming server handler.");
+        await continuation(requestStream, responseStream, context);
+    }
 
-        public async override Task DuplexStreamingServerHandler<TRequest, TResponse>(
-            IAsyncStreamReader<TRequest> requestStream,
-            IServerStreamWriter<TResponse> responseStream,
-            ServerCallContext context,
-            DuplexStreamingServerMethod<TRequest, TResponse> continuation)
-        {
-            _logger.LogInformation("JUST ANOTHER INTERCEPTOR - duplex streaming server handler.");
-            await continuation(requestStream, responseStream, context);
-        }
+    public async override Task ServerStreamingServerHandler<TRequest, TResponse>(
+        TRequest request,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        ServerStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("JUST ANOTHER INTERCEPTOR - server streaming server handler.");
+        await continuation(request, responseStream, context);
+    }
 
-        public async override Task ServerStreamingServerHandler<TRequest, TResponse>(
-            TRequest request,
-            IServerStreamWriter<TResponse> responseStream,
-            ServerCallContext context,
-            ServerStreamingServerMethod<TRequest, TResponse> continuation)
-        {
-            _logger.LogInformation("JUST ANOTHER INTERCEPTOR - server streaming server handler.");
-            await continuation(request, responseStream, context);
-        }
-
-        public async override Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
-            TRequest request,
-            ServerCallContext context,
-            UnaryServerMethod<TRequest, TResponse> continuation)
-        {
-            _logger.LogInformation("JUST ANOTHER INTERCEPTOR - unary server handler.");
-            return await continuation(request, context);
-        }
+    public async override Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("JUST ANOTHER INTERCEPTOR - unary server handler.");
+        return await continuation(request, context);
     }
 }

--- a/samples/GrpcAPI/Program.cs
+++ b/samples/GrpcAPI/Program.cs
@@ -1,30 +1,29 @@
-namespace GrpcAPI
+namespace GrpcAPI;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+public class Program
 {
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.Extensions.Logging;
-
-    public class Program
+    public static void Main(string[] args)
     {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
-
-        // Additional configuration is required to successfully run gRPC on macOS.
-        // For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureLogging(logging =>
-                {
-                    logging.ClearProviders();
-                    logging.AddConsole();
-                })
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup>();
-                });
-
-        protected Program() { }
+        CreateHostBuilder(args).Build().Run();
     }
+
+    // Additional configuration is required to successfully run gRPC on macOS.
+    // For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddConsole();
+            })
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
+
+    protected Program() { }
 }

--- a/samples/GrpcAPI/Services/GreeterService.cs
+++ b/samples/GrpcAPI/Services/GreeterService.cs
@@ -1,128 +1,127 @@
-namespace GrpcAPI
+namespace GrpcAPI;
+
+using FluentValidation.Results;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ToolPack.Exceptions.Base.Entities;
+using ToolPack.Exceptions.Base.Guard;
+
+public class GreeterService : Greeter.GreeterBase
 {
-    using FluentValidation.Results;
-    using Grpc.Core;
-    using Microsoft.Extensions.Logging;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using ToolPack.Exceptions.Base.Entities;
-    using ToolPack.Exceptions.Base.Guard;
-
-    public class GreeterService : Greeter.GreeterBase
+    private readonly ILogger<GreeterService> _logger;
+    public GreeterService(ILogger<GreeterService> logger)
     {
-        private readonly ILogger<GreeterService> _logger;
-        public GreeterService(ILogger<GreeterService> logger)
-        {
-            _logger = logger;
-        }
+        _logger = logger;
+    }
 
-        public override Task<Response> GetAlreadyExists(Request request, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC unary request");
+    public override Task<Response> GetAlreadyExists(Request request, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC unary request");
 
-            _logger.LogInformation("Throwing AlreadyExistsException");
+        _logger.LogInformation("Throwing AlreadyExistsException");
 
-            ThrowWhen.ConditionFails(false, new AlreadyExistsException());
+        ThrowWhen.ConditionFails(false, new AlreadyExistsException());
 
-            return Task.FromResult(new Response());
-        }
+        return Task.FromResult(new Response());
+    }
 
-        public override Task GetAlreadyExistsStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC stream request");
+    public override Task GetAlreadyExistsStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC stream request");
 
-            _logger.LogInformation("Throwing AlreadyExistsException");
+        _logger.LogInformation("Throwing AlreadyExistsException");
 
-            ThrowWhen.ConditionFails(false, new AlreadyExistsException());
-            return Task.CompletedTask;
-        }
+        ThrowWhen.ConditionFails(false, new AlreadyExistsException());
+        return Task.CompletedTask;
+    }
 
-        public override Task<Response> GetCustomBaseException(Request request, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC unary request");
+    public override Task<Response> GetCustomBaseException(Request request, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC unary request");
 
-            _logger.LogInformation("Throwing CustomBaseException");
+        _logger.LogInformation("Throwing CustomBaseException");
 
-            throw new CustomBaseException();
-        }
+        throw new CustomBaseException();
+    }
 
-        public override Task GetCustomBaseExceptionStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC stream request");
+    public override Task GetCustomBaseExceptionStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC stream request");
 
-            _logger.LogInformation("Throwing CustomBaseException");
+        _logger.LogInformation("Throwing CustomBaseException");
 
-            throw new CustomBaseException();
-        }
+        throw new CustomBaseException();
+    }
 
-        public override Task<Response> GetNotFound(Request request, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC unary request");
+    public override Task<Response> GetNotFound(Request request, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC unary request");
 
-            _logger.LogInformation("Throwing NotFoundException");
+        _logger.LogInformation("Throwing NotFoundException");
 
-            ThrowWhen.ArgumentNullThrowNotFound<string>(null, "argument description", "argument key");
+        ThrowWhen.ArgumentNullThrowNotFound<string>(null, "argument description", "argument key");
 
-            return Task.FromResult(new Response());
-        }
+        return Task.FromResult(new Response());
+    }
 
-        public override Task GetNotFoundStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC stream request");
+    public override Task GetNotFoundStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC stream request");
 
-            _logger.LogInformation("Throwing NotFoundException");
+        _logger.LogInformation("Throwing NotFoundException");
 
-            ThrowWhen.ArgumentNullThrowNotFound<string>(null, "argument description", "argument key");
-            return Task.CompletedTask;
-        }
+        ThrowWhen.ArgumentNullThrowNotFound<string>(null, "argument description", "argument key");
+        return Task.CompletedTask;
+    }
 
-        public override Task<Response> GetThirdPartyException(Request request, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC unary request");
+    public override Task<Response> GetThirdPartyException(Request request, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC unary request");
 
-            _logger.LogInformation("Throwing ExternalComponentException");
+        _logger.LogInformation("Throwing ExternalComponentException");
 
-            ThrowWhen.ConditionFails(false, new ExternalComponentException());
+        ThrowWhen.ConditionFails(false, new ExternalComponentException());
 
-            return Task.FromResult(new Response());
-        }
+        return Task.FromResult(new Response());
+    }
 
-        public override Task GetThirdPartyExceptionStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC stream request");
+    public override Task GetThirdPartyExceptionStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC stream request");
 
-            _logger.LogInformation("Throwing ExternalComponentException");
+        _logger.LogInformation("Throwing ExternalComponentException");
 
-            ThrowWhen.ConditionFails(false, new ExternalComponentException());
-            return Task.CompletedTask;
-        }
+        ThrowWhen.ConditionFails(false, new ExternalComponentException());
+        return Task.CompletedTask;
+    }
 
-        public override Task<Response> GetValidationFailedException(Request request, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC unary request");
+    public override Task<Response> GetValidationFailedException(Request request, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC unary request");
 
-            _logger.LogInformation("Throwing ValidationFailedException");
+        _logger.LogInformation("Throwing ValidationFailedException");
 
-            throw new ValidationFailedException(
-                new List<ValidationFailure>()
-                {
-                    new("Prop1 Name", "Prop1 error message"),
-                    new("Prop2 Name", "Prop2 error message")
-                });
-        }
+        throw new ValidationFailedException(
+            new List<ValidationFailure>()
+            {
+                new("Prop1 Name", "Prop1 error message"),
+                new("Prop2 Name", "Prop2 error message")
+            });
+    }
 
-        public override Task GetValidationFailedExceptionStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
-        {
-            _logger.LogInformation($"gRPC stream request");
+    public override Task GetValidationFailedExceptionStream(Request request, IServerStreamWriter<Response> responseStream, ServerCallContext context)
+    {
+        _logger.LogInformation($"gRPC stream request");
 
-            _logger.LogInformation("Throwing ValidationFailedException");
+        _logger.LogInformation("Throwing ValidationFailedException");
 
-            throw new ValidationFailedException(
-                new List<ValidationFailure>()
-                {
-                    new("Prop1 Name", "Prop1 error message"),
-                    new("Prop2 Name", "Prop2 error message")
-                });
-        }
+        throw new ValidationFailedException(
+            new List<ValidationFailure>()
+            {
+                new("Prop1 Name", "Prop1 error message"),
+                new("Prop2 Name", "Prop2 error message")
+            });
     }
 }

--- a/samples/GrpcAPI/Startup.cs
+++ b/samples/GrpcAPI/Startup.cs
@@ -1,50 +1,49 @@
-namespace GrpcAPI
+namespace GrpcAPI;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ToolPack.Exceptions.Web.Extensions;
+
+public class Startup
 {
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-    using ToolPack.Exceptions.Web.Extensions;
-
-    public class Startup
+    public Startup(IConfiguration configuration)
     {
-        public Startup(IConfiguration configuration)
+        Configuration = configuration;
+    }
+
+    public IConfiguration Configuration { get; }
+
+    // This method gets called by the runtime. Use this method to add services to the container.
+    // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddGrpc(options => options.Interceptors.Add<JustAnInterceptor>());
+        services.AddToolPackExceptionsGrpc()
+                .AddGrpc(options => options.Interceptors.Add<JustAnotherInterceptor>());
+    }
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
         {
-            Configuration = configuration;
+            app.UseDeveloperExceptionPage();
         }
 
-        public IConfiguration Configuration { get; }
+        app.UseRouting();
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
-        public void ConfigureServices(IServiceCollection services)
+        app.UseEndpoints(endpoints =>
         {
-            services.AddGrpc(options => options.Interceptors.Add<JustAnInterceptor>());
-            services.AddToolPackExceptionsGrpc()
-                    .AddGrpc(options => options.Interceptors.Add<JustAnotherInterceptor>());
-        }
+            endpoints.MapGrpcService<GreeterService>();
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            if (env.IsDevelopment())
+            endpoints.MapGet("/", async context =>
             {
-                app.UseDeveloperExceptionPage();
-            }
-
-            app.UseRouting();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapGrpcService<GreeterService>();
-
-                endpoints.MapGet("/", async context =>
-                {
-                    await context.Response.WriteAsync("Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
-                });
+                await context.Response.WriteAsync("Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
             });
-        }
+        });
     }
 }

--- a/samples/RestAPI/Controllers/ExceptionsController.cs
+++ b/samples/RestAPI/Controllers/ExceptionsController.cs
@@ -1,69 +1,68 @@
-namespace RestAPI.Controllers
+namespace RestAPI.Controllers;
+
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using ToolPack.Exceptions.Base.Entities;
+using ToolPack.Exceptions.Base.Guard;
+
+[ApiController]
+[Route("exceptions")]
+public class ExceptionsController : ControllerBase
 {
-    using FluentValidation.Results;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.Logging;
-    using System.Collections.Generic;
-    using ToolPack.Exceptions.Base.Entities;
-    using ToolPack.Exceptions.Base.Guard;
+    private readonly ILogger<ExceptionsController> _logger;
 
-    [ApiController]
-    [Route("exceptions")]
-    public class ExceptionsController : ControllerBase
+    public ExceptionsController(ILogger<ExceptionsController> logger)
     {
-        private readonly ILogger<ExceptionsController> _logger;
+        _logger = logger;
+    }
 
-        public ExceptionsController(ILogger<ExceptionsController> logger)
-        {
-            _logger = logger;
-        }
+    [HttpGet("already-exists")]
+    public IActionResult GetAlreadyExists()
+    {
+        _logger.LogInformation("Throwing AlreadyExistsException");
 
-        [HttpGet("already-exists")]
-        public IActionResult GetAlreadyExists()
-        {
-            _logger.LogInformation("Throwing AlreadyExistsException");
+        ThrowWhen.ConditionFails(false, new AlreadyExistsException());
+        return Ok();
+    }
 
-            ThrowWhen.ConditionFails(false, new AlreadyExistsException());
-            return Ok();
-        }
+    [HttpGet("custom-base-exception")]
+    public IActionResult GetCustomBaseException()
+    {
+        _logger.LogInformation("Throwing CustomBaseException");
 
-        [HttpGet("custom-base-exception")]
-        public IActionResult GetCustomBaseException()
-        {
-            _logger.LogInformation("Throwing CustomBaseException");
+        throw new CustomBaseException();
+    }
 
-            throw new CustomBaseException();
-        }
+    [HttpGet("external-component")]
+    public IActionResult GetExternalException()
+    {
+        _logger.LogInformation("Throwing ExternalComponentException");
 
-        [HttpGet("external-component")]
-        public IActionResult GetExternalException()
-        {
-            _logger.LogInformation("Throwing ExternalComponentException");
+        ThrowWhen.ConditionFails(false, new ExternalComponentException("component name", "component description"));
+        return Ok();
+    }
 
-            ThrowWhen.ConditionFails(false, new ExternalComponentException("component name", "component description"));
-            return Ok();
-        }
+    [HttpGet("not-found")]
+    public IActionResult GetNotFound()
+    {
+        _logger.LogInformation("Throwing NotFoundException");
 
-        [HttpGet("not-found")]
-        public IActionResult GetNotFound()
-        {
-            _logger.LogInformation("Throwing NotFoundException");
+        ThrowWhen.ArgumentNullThrowNotFound<string>(null, "argument description", "argument identifier");
+        return Ok();
+    }
 
-            ThrowWhen.ArgumentNullThrowNotFound<string>(null, "argument description", "argument identifier");
-            return Ok();
-        }
+    [HttpGet("validation-failed-exception")]
+    public IActionResult GetValidationFailedException()
+    {
+        _logger.LogInformation("Throwing ValidationFailedException");
 
-        [HttpGet("validation-failed-exception")]
-        public IActionResult GetValidationFailedException()
-        {
-            _logger.LogInformation("Throwing ValidationFailedException");
-
-            throw new ValidationFailedException(
-                new List<ValidationFailure>()
-                {
-                    new("Prop1 Name", "Prop1 error message"),
-                    new("Prop2 Name", "Prop2 error message")
-                });
-        }
+        throw new ValidationFailedException(
+            new List<ValidationFailure>()
+            {
+                new("Prop1 Name", "Prop1 error message"),
+                new("Prop2 Name", "Prop2 error message")
+            });
     }
 }

--- a/samples/RestAPI/Program.cs
+++ b/samples/RestAPI/Program.cs
@@ -1,22 +1,21 @@
-namespace RestAPI
+namespace RestAPI;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+public class Program
 {
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Hosting;
-
-    public class Program
+    public static void Main(string[] args)
     {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
-
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup>();
-                });
-
-        protected Program() { }
+        CreateHostBuilder(args).Build().Run();
     }
+
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
+
+    protected Program() { }
 }

--- a/samples/RestAPI/RestAPI.csproj
+++ b/samples/RestAPI/RestAPI.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/RestAPI/Startup.cs
+++ b/samples/RestAPI/Startup.cs
@@ -1,53 +1,52 @@
-namespace RestAPI
+namespace RestAPI;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+using ToolPack.Exceptions.Web.Extensions;
+
+public class Startup
 {
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.OpenApi.Models;
-    using ToolPack.Exceptions.Web.Extensions;
-
-    public class Startup
+    public Startup(IConfiguration configuration)
     {
-        public Startup(IConfiguration configuration)
+        Configuration = configuration;
+    }
+
+    public IConfiguration Configuration { get; }
+
+    // This method gets called by the runtime. Use this method to add services to the container.
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllers();
+        services.AddSwaggerGen(c =>
         {
-            Configuration = configuration;
+            c.SwaggerDoc("v1", new OpenApiInfo { Title = "RestAPI", Version = "v1" });
+        });
+
+        services.AddToolPackExceptions();
+    }
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
+        {
+            app.UseDeveloperExceptionPage();
+            app.UseSwagger();
+            app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "RestAPI v1"));
         }
 
-        public IConfiguration Configuration { get; }
+        app.UseToolPackExceptionsMiddleware();
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
+        app.UseHttpsRedirection();
+        app.UseRouting();
+        app.UseAuthorization();
+        app.UseEndpoints(endpoints =>
         {
-            services.AddControllers();
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "RestAPI", Version = "v1" });
-            });
-
-            services.AddToolPackExceptions();
-        }
-
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-                app.UseSwagger();
-                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "RestAPI v1"));
-            }
-
-            app.UseToolPackExceptionsMiddleware();
-
-            app.UseHttpsRedirection();
-            app.UseRouting();
-            app.UseAuthorization();
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllers();
-            });
-        }
+            endpoints.MapControllers();
+        });
     }
 }

--- a/samples/RestAPI/WeatherForecast.cs
+++ b/samples/RestAPI/WeatherForecast.cs
@@ -1,15 +1,14 @@
-namespace RestAPI
+namespace RestAPI;
+
+using System;
+
+public class WeatherForecast
 {
-    using System;
+    public DateTime Date { get; set; }
 
-    public class WeatherForecast
-    {
-        public DateTime Date { get; set; }
+    public int TemperatureC { get; set; }
 
-        public int TemperatureC { get; set; }
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
-        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-
-        public string Summary { get; set; }
-    }
+    public string Summary { get; set; }
 }

--- a/src/ToolPack.Exceptions.Base/Entities/AlreadyExistsException.cs
+++ b/src/ToolPack.Exceptions.Base/Entities/AlreadyExistsException.cs
@@ -1,44 +1,43 @@
-namespace ToolPack.Exceptions.Base.Entities
+namespace ToolPack.Exceptions.Base.Entities;
+
+using System;
+using System.Runtime.Serialization;
+
+/// <summary>
+///   Exception related with an entity that already exists.
+/// </summary>
+[Serializable]
+public class AlreadyExistsException : CustomBaseException
 {
-    using System;
-    using System.Runtime.Serialization;
+    /// <summary>The default message.</summary>
+    public new const string MessageDefault = "A failure occurred due to an entity that already exists.";
 
-    /// <summary>
-    ///   Exception related with an entity that already exists.
-    /// </summary>
-    [Serializable]
-    public class AlreadyExistsException : CustomBaseException
-    {
-        /// <summary>The default message.</summary>
-        public new const string MessageDefault = "A failure occurred due to an entity that already exists.";
+    /// <summary>Initializes a new instance of the AlreadyExistsException class.</summary>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public AlreadyExistsException(Exception innerException = null)
+        : base(MessageDefault, innerException) { }
 
-        /// <summary>Initializes a new instance of the AlreadyExistsException class.</summary>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public AlreadyExistsException(Exception innerException = null)
-            : base(MessageDefault, innerException) { }
+    /// <summary>Initializes a new instance of the AlreadyExistsException class.</summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public AlreadyExistsException(string message, Exception innerException = null)
+        : base(SetValidMessageOrDefault(message, MessageDefault), innerException) { }
 
-        /// <summary>Initializes a new instance of the AlreadyExistsException class.</summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public AlreadyExistsException(string message, Exception innerException = null)
-            : base(SetValidMessageOrDefault(message, MessageDefault), innerException) { }
+    /// <summary>Initializes a new instance of the AlreadyExistsException class.</summary>
+    /// <param name="entityName">Name of the entity.</param>
+    /// <param name="entityKey">The entity key.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public AlreadyExistsException(
+        string entityName,
+        object entityKey,
+        Exception innerException = null)
+        : base(
+              MessageDefault + $" | Entity: '{entityName}'. Entity key: '{entityKey}'.", innerException)
+    { }
 
-        /// <summary>Initializes a new instance of the AlreadyExistsException class.</summary>
-        /// <param name="entityName">Name of the entity.</param>
-        /// <param name="entityKey">The entity key.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public AlreadyExistsException(
-            string entityName,
-            object entityKey,
-            Exception innerException = null)
-            : base(
-                  MessageDefault + $" | Entity: '{entityName}'. Entity key: '{entityKey}'.", innerException)
-        { }
-
-        /// <summary>Initializes a new instance of the <see cref="AlreadyExistsException" /> class.</summary>
-        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
-        protected AlreadyExistsException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
-    }
+    /// <summary>Initializes a new instance of the <see cref="AlreadyExistsException" /> class.</summary>
+    /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
+    protected AlreadyExistsException(SerializationInfo info, StreamingContext context)
+        : base(info, context) { }
 }

--- a/src/ToolPack.Exceptions.Base/Entities/CustomBaseException.cs
+++ b/src/ToolPack.Exceptions.Base/Entities/CustomBaseException.cs
@@ -1,41 +1,40 @@
-namespace ToolPack.Exceptions.Base.Entities
+namespace ToolPack.Exceptions.Base.Entities;
+
+using System;
+using System.Runtime.Serialization;
+
+/// <summary>
+///   Exception related with a failure in an owned system.
+/// </summary>
+[Serializable]
+public class CustomBaseException : Exception
 {
-    using System;
-    using System.Runtime.Serialization;
+    /// <summary>The default message.</summary>
+    public const string MessageDefault = "A failure related with an owned system occurred.";
 
-    /// <summary>
-    ///   Exception related with a failure in an owned system.
-    /// </summary>
-    [Serializable]
-    public class CustomBaseException : Exception
+    /// <summary>Initializes a new instance of the CustomBaseException class.</summary>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public CustomBaseException(Exception innerException = null)
+        : base(MessageDefault, innerException) { }
+
+    /// <summary>Initializes a new instance of the CustomBaseException class.</summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public CustomBaseException(string message, Exception innerException = null)
+        : base(SetValidMessageOrDefault(message, MessageDefault), innerException) { }
+
+    /// <summary>Initializes a new instance of the <see cref="CustomBaseException" /> class.</summary>
+    /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
+    protected CustomBaseException(SerializationInfo info, StreamingContext context)
+        : base(info, context) { }
+
+    /// <summary>Sets a valid message or default.</summary>
+    /// <param name="message">The message to set.</param>
+    /// <param name="defaultMessage">The default message.</param>
+    /// <returns>A string with the defined message.</returns>
+    protected static string SetValidMessageOrDefault(string message, string defaultMessage)
     {
-        /// <summary>The default message.</summary>
-        public const string MessageDefault = "A failure related with an owned system occurred.";
-
-        /// <summary>Initializes a new instance of the CustomBaseException class.</summary>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public CustomBaseException(Exception innerException = null)
-            : base(MessageDefault, innerException) { }
-
-        /// <summary>Initializes a new instance of the CustomBaseException class.</summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public CustomBaseException(string message, Exception innerException = null)
-            : base(SetValidMessageOrDefault(message, MessageDefault), innerException) { }
-
-        /// <summary>Initializes a new instance of the <see cref="CustomBaseException" /> class.</summary>
-        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
-        protected CustomBaseException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
-
-        /// <summary>Sets a valid message or default.</summary>
-        /// <param name="message">The message to set.</param>
-        /// <param name="defaultMessage">The default message.</param>
-        /// <returns>A string with the defined message.</returns>
-        protected static string SetValidMessageOrDefault(string message, string defaultMessage)
-        {
-            return string.IsNullOrWhiteSpace(message) ? defaultMessage : message;
-        }
+        return string.IsNullOrWhiteSpace(message) ? defaultMessage : message;
     }
 }

--- a/src/ToolPack.Exceptions.Base/Entities/ExternalComponentException.cs
+++ b/src/ToolPack.Exceptions.Base/Entities/ExternalComponentException.cs
@@ -1,45 +1,44 @@
-namespace ToolPack.Exceptions.Base.Entities
+namespace ToolPack.Exceptions.Base.Entities;
+
+using System;
+using System.Runtime.Serialization;
+
+/// <summary>
+///   Exception related with an external component.
+/// </summary>
+[Serializable]
+public class ExternalComponentException : CustomBaseException
 {
-    using System;
-    using System.Runtime.Serialization;
+    /// <summary>The default message.</summary>
+    public new const string MessageDefault = "A failure related with an external component occurred.";
 
-    /// <summary>
-    ///   Exception related with an external component.
-    /// </summary>
-    [Serializable]
-    public class ExternalComponentException : CustomBaseException
-    {
-        /// <summary>The default message.</summary>
-        public new const string MessageDefault = "A failure related with an external component occurred.";
+    /// <summary>Initializes a new instance of the ExternalComponentException class.</summary>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public ExternalComponentException(Exception innerException = null)
+        : base(MessageDefault, innerException) { }
 
-        /// <summary>Initializes a new instance of the ExternalComponentException class.</summary>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public ExternalComponentException(Exception innerException = null)
-            : base(MessageDefault, innerException) { }
+    /// <summary>Initializes a new instance of the ExternalComponentException class.</summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public ExternalComponentException(string message, Exception innerException = null)
+        : base(SetValidMessageOrDefault(message, MessageDefault), innerException) { }
 
-        /// <summary>Initializes a new instance of the ExternalComponentException class.</summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public ExternalComponentException(string message, Exception innerException = null)
-            : base(SetValidMessageOrDefault(message, MessageDefault), innerException) { }
+    /// <summary>Initializes a new instance of the ExternalComponentException class.</summary>
+    /// <param name="componentName">Name of the component.</param>
+    /// <param name="componentDescription">The component description.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public ExternalComponentException(
+        string componentName,
+        string componentDescription,
+        Exception innerException = null)
+        : base(
+            MessageDefault + $" | Component name: '{componentName}'. Component description: '{componentDescription}'.",
+            innerException)
+    { }
 
-        /// <summary>Initializes a new instance of the ExternalComponentException class.</summary>
-        /// <param name="componentName">Name of the component.</param>
-        /// <param name="componentDescription">The component description.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public ExternalComponentException(
-            string componentName,
-            string componentDescription,
-            Exception innerException = null)
-            : base(
-                MessageDefault + $" | Component name: '{componentName}'. Component description: '{componentDescription}'.",
-                innerException)
-        { }
-
-        /// <summary>Initializes a new instance of the <see cref="ExternalComponentException" /> class.</summary>
-        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
-        protected ExternalComponentException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
-    }
+    /// <summary>Initializes a new instance of the <see cref="ExternalComponentException" /> class.</summary>
+    /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
+    protected ExternalComponentException(SerializationInfo info, StreamingContext context)
+        : base(info, context) { }
 }

--- a/src/ToolPack.Exceptions.Base/Entities/NotFoundException.cs
+++ b/src/ToolPack.Exceptions.Base/Entities/NotFoundException.cs
@@ -1,44 +1,43 @@
-namespace ToolPack.Exceptions.Base.Entities
+namespace ToolPack.Exceptions.Base.Entities;
+
+using System;
+using System.Runtime.Serialization;
+
+/// <summary>
+///   Exception related with an entity that was not found.
+/// </summary>
+[Serializable]
+public class NotFoundException : CustomBaseException
 {
-    using System;
-    using System.Runtime.Serialization;
+    /// <summary>The default message.</summary>
+    public new const string MessageDefault = "A failure occurred due to an entity that was not found.";
 
-    /// <summary>
-    ///   Exception related with an entity that was not found.
-    /// </summary>
-    [Serializable]
-    public class NotFoundException : CustomBaseException
-    {
-        /// <summary>The default message.</summary>
-        public new const string MessageDefault = "A failure occurred due to an entity that was not found.";
+    /// <summary>Initializes a new instance of the NotFoundException class.</summary>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public NotFoundException(Exception innerException = null)
+        : base(MessageDefault, innerException) { }
 
-        /// <summary>Initializes a new instance of the NotFoundException class.</summary>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public NotFoundException(Exception innerException = null)
-            : base(MessageDefault, innerException) { }
+    /// <summary>Initializes a new instance of the NotFoundException class.</summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public NotFoundException(string message, Exception innerException = null)
+        : base(SetValidMessageOrDefault(message, MessageDefault), innerException) { }
 
-        /// <summary>Initializes a new instance of the NotFoundException class.</summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public NotFoundException(string message, Exception innerException = null)
-            : base(SetValidMessageOrDefault(message, MessageDefault), innerException) { }
+    /// <summary>Initializes a new instance of the NotFoundException class.</summary>
+    /// <param name="entityName">Name of the entity.</param>
+    /// <param name="entityKey">The entity key.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public NotFoundException(
+        string entityName,
+        string entityKey,
+        Exception innerException = null)
+        : base(
+              MessageDefault + $" | Entity: '{entityName}'. Entity key: '{entityKey}'.", innerException)
+    { }
 
-        /// <summary>Initializes a new instance of the NotFoundException class.</summary>
-        /// <param name="entityName">Name of the entity.</param>
-        /// <param name="entityKey">The entity key.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public NotFoundException(
-            string entityName,
-            string entityKey,
-            Exception innerException = null)
-            : base(
-                  MessageDefault + $" | Entity: '{entityName}'. Entity key: '{entityKey}'.", innerException)
-        { }
-
-        /// <summary>Initializes a new instance of the <see cref="NotFoundException" /> class.</summary>
-        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
-        protected NotFoundException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
-    }
+    /// <summary>Initializes a new instance of the <see cref="NotFoundException" /> class.</summary>
+    /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
+    protected NotFoundException(SerializationInfo info, StreamingContext context)
+        : base(info, context) { }
 }

--- a/src/ToolPack.Exceptions.Base/Entities/ValidationFailedException.cs
+++ b/src/ToolPack.Exceptions.Base/Entities/ValidationFailedException.cs
@@ -1,50 +1,49 @@
-namespace ToolPack.Exceptions.Base.Entities
+namespace ToolPack.Exceptions.Base.Entities;
+
+using FluentValidation.Results;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+/// <summary>
+///   Exception related with a validation failure.
+/// </summary>
+[Serializable]
+public class ValidationFailedException : CustomBaseException
 {
-    using FluentValidation.Results;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Runtime.Serialization;
+    /// <summary>The default message.</summary>
+    public new const string MessageDefault = "One or more validation failures occurred.";
 
-    /// <summary>
-    ///   Exception related with a validation failure.
-    /// </summary>
-    [Serializable]
-    public class ValidationFailedException : CustomBaseException
+    /// <summary>Gets the errors.</summary>
+    /// <value>The errors.</value>
+    public IDictionary<string, string[]> Errors { get; } = new Dictionary<string, string[]>();
+
+    /// <summary>Initializes a new instance of the ValidationFailedException class.</summary>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public ValidationFailedException(Exception innerException = null)
+        : base(MessageDefault, innerException) { }
+
+    /// <summary>Initializes a new instance of the ValidationFailedException class.</summary>
+    /// <param name="failures">The failures that occurred.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public ValidationFailedException(IEnumerable<ValidationFailure> failures, Exception innerException = null)
+        : this(innerException)
     {
-        /// <summary>The default message.</summary>
-        public new const string MessageDefault = "One or more validation failures occurred.";
+        var failureGroups = failures?.GroupBy(e => e.PropertyName, e => e.ErrorMessage) ?? Enumerable.Empty<IGrouping<string, string>>();
 
-        /// <summary>Gets the errors.</summary>
-        /// <value>The errors.</value>
-        public IDictionary<string, string[]> Errors { get; } = new Dictionary<string, string[]>();
-
-        /// <summary>Initializes a new instance of the ValidationFailedException class.</summary>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public ValidationFailedException(Exception innerException = null)
-            : base(MessageDefault, innerException) { }
-
-        /// <summary>Initializes a new instance of the ValidationFailedException class.</summary>
-        /// <param name="failures">The failures that occurred.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public ValidationFailedException(IEnumerable<ValidationFailure> failures, Exception innerException = null)
-            : this(innerException)
+        foreach (var failureGroup in failureGroups)
         {
-            var failureGroups = failures?.GroupBy(e => e.PropertyName, e => e.ErrorMessage) ?? Enumerable.Empty<IGrouping<string, string>>();
+            var propertyName = failureGroup.Key;
+            var propertyFailures = failureGroup.ToArray();
 
-            foreach (var failureGroup in failureGroups)
-            {
-                var propertyName = failureGroup.Key;
-                var propertyFailures = failureGroup.ToArray();
-
-                Errors.Add(propertyName, propertyFailures);
-            }
+            Errors.Add(propertyName, propertyFailures);
         }
-
-        /// <summary>Initializes a new instance of the <see cref="ValidationFailedException" /> class.</summary>
-        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
-        protected ValidationFailedException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
     }
+
+    /// <summary>Initializes a new instance of the <see cref="ValidationFailedException" /> class.</summary>
+    /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo">SerializationInfo</see> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext">StreamingContext</see> that contains contextual information about the source or destination.</param>
+    protected ValidationFailedException(SerializationInfo info, StreamingContext context)
+        : base(info, context) { }
 }

--- a/src/ToolPack.Exceptions.Base/Guard/ThrowWhen.cs
+++ b/src/ToolPack.Exceptions.Base/Guard/ThrowWhen.cs
@@ -1,82 +1,81 @@
-namespace ToolPack.Exceptions.Base.Guard
+namespace ToolPack.Exceptions.Base.Guard;
+
+using System;
+using System.Linq;
+using ToolPack.Exceptions.Base.Entities;
+
+/// <summary>
+/// Class with methods to guard arguments/results against unwanted conditions. 
+/// If the unwanted conditions occur, exceptions are thrown.
+/// </summary>
+// TODO: Add similar class, but returning result responses instead of throwing
+public static class ThrowWhen
 {
-    using System;
-    using System.Linq;
-    using ToolPack.Exceptions.Base.Entities;
-
-    /// <summary>
-    /// Class with methods to guard arguments/results against unwanted conditions. 
-    /// If the unwanted conditions occur, exceptions are thrown.
-    /// </summary>
-    // TODO: Add similar class, but returning result responses instead of throwing
-    public static class ThrowWhen
+    /// <summary>Throws an exception, if a condition is not met.</summary>
+    /// <typeparam name="T">Exception type.</typeparam>
+    /// <param name="condition">Condition to validate.</param>
+    /// <param name="exception">Exception to throw.</param>
+    public static void ConditionFails<T>(bool condition, T exception)
+        where T : Exception
     {
-        /// <summary>Throws an exception, if a condition is not met.</summary>
-        /// <typeparam name="T">Exception type.</typeparam>
-        /// <param name="condition">Condition to validate.</param>
-        /// <param name="exception">Exception to throw.</param>
-        public static void ConditionFails<T>(bool condition, T exception)
-            where T : Exception
+        if (!condition)
         {
-            if (!condition)
-            {
-                throw exception;
-            }
+            throw exception;
         }
+    }
 
-        /// <summary>Throws an ArgumentNullException, if the argument is null.</summary>
-        /// <typeparam name="T">Argument type.</typeparam>
-        /// <param name="argument">Argument to validate.</param>
-        /// <param name="argumentDescription">Description of the argument.</param>
-        /// <param name="exceptionMessage">Message of the exception, in case it is thrown.</param>
-        public static void ArgumentNull<T>(T argument, string argumentDescription, string exceptionMessage = null)
+    /// <summary>Throws an ArgumentNullException, if the argument is null.</summary>
+    /// <typeparam name="T">Argument type.</typeparam>
+    /// <param name="argument">Argument to validate.</param>
+    /// <param name="argumentDescription">Description of the argument.</param>
+    /// <param name="exceptionMessage">Message of the exception, in case it is thrown.</param>
+    public static void ArgumentNull<T>(T argument, string argumentDescription, string exceptionMessage = null)
+    {
+        ConditionFails(argument is not null, new ArgumentNullException(argumentDescription, exceptionMessage));
+    }
+
+    /// <summary>Throws an ArgumentNullException when an argument of the list is null.</summary>
+    /// <param name="argumentDefinitions">Collection of argument definitions to validate. Each definition includes the argument's object and description/name.</param>
+    public static void ArgumentNull(params (object, string)[] argumentDefinitions)
+    {
+        foreach (var argDefinition in argumentDefinitions ?? Enumerable.Empty<(object, string)>())
         {
-            ConditionFails(argument is not null, new ArgumentNullException(argumentDescription, exceptionMessage));
+            ArgumentNull(argDefinition.Item1, argDefinition.Item2);
         }
+    }
 
-        /// <summary>Throws an ArgumentNullException when an argument of the list is null.</summary>
-        /// <param name="argumentDefinitions">Collection of argument definitions to validate. Each definition includes the argument's object and description/name.</param>
-        public static void ArgumentNull(params (object, string)[] argumentDefinitions)
-        {
-            foreach (var argDefinition in argumentDefinitions ?? Enumerable.Empty<(object, string)>())
-            {
-                ArgumentNull(argDefinition.Item1, argDefinition.Item2);
-            }
-        }
+    /// <summary>Throws an applicational NotFoundException when the provided argument is null.</summary>
+    /// <param name="argument">String argument to validate.</param>
+    /// <param name="argumentDescription">Description/Name of the argument.</param>
+    /// <param name="argumentKey">Key/identifier of the argument.</param>
+    public static void ArgumentNullThrowNotFound<T>(T argument, string argumentDescription, string argumentKey)
+    {
+        ConditionFails(argument is not null, new NotFoundException(argumentDescription, argumentKey));
+    }
 
-        /// <summary>Throws an applicational NotFoundException when the provided argument is null.</summary>
-        /// <param name="argument">String argument to validate.</param>
-        /// <param name="argumentDescription">Description/Name of the argument.</param>
-        /// <param name="argumentKey">Key/identifier of the argument.</param>
-        public static void ArgumentNullThrowNotFound<T>(T argument, string argumentDescription, string argumentKey)
-        {
-            ConditionFails(argument is not null, new NotFoundException(argumentDescription, argumentKey));
-        }
+    /// <summary>Throws an ArgumentOutOfRangeException, if a condition is not met.</summary>
+    /// <param name="condition">Condition to validate.</param>
+    /// <param name="argumentDescription">Description of the argument.</param>
+    public static void ArgumentOutOfRange(bool condition, string argumentDescription)
+    {
+        ConditionFails(condition, new ArgumentOutOfRangeException(argumentDescription));
+    }
 
-        /// <summary>Throws an ArgumentOutOfRangeException, if a condition is not met.</summary>
-        /// <param name="condition">Condition to validate.</param>
-        /// <param name="argumentDescription">Description of the argument.</param>
-        public static void ArgumentOutOfRange(bool condition, string argumentDescription)
-        {
-            ConditionFails(condition, new ArgumentOutOfRangeException(argumentDescription));
-        }
+    /// <summary>Throws an ArgumentException, if the argument string is null, empty or white spaces.</summary>
+    /// <param name="argument">String argument to validate.</param>
+    /// <param name="argumentDescription">Description of the argument.</param>
+    public static void ArgumentStringNullOrWhiteSpace(string argument, string argumentDescription)
+    {
+        ConditionFails(!string.IsNullOrWhiteSpace(argument), new ArgumentException($"String cannot be null, empty or white space. Argument description: {argumentDescription}"));
+    }
 
-        /// <summary>Throws an ArgumentException, if the argument string is null, empty or white spaces.</summary>
-        /// <param name="argument">String argument to validate.</param>
-        /// <param name="argumentDescription">Description of the argument.</param>
-        public static void ArgumentStringNullOrWhiteSpace(string argument, string argumentDescription)
+    /// <summary>Throws an ArgumentException when an argument string of the list is null, empty or white spaces.</summary>
+    /// <param name="argumentDefinitions">Collection of argument definitions to validate. Each definition includes the argument's string value and description/name.</param>
+    public static void ArgumentStringNullOrWhiteSpace(params (string, string)[] argumentDefinitions)
+    {
+        foreach (var argDefinition in argumentDefinitions ?? Enumerable.Empty<(string, string)>())
         {
-            ConditionFails(!string.IsNullOrWhiteSpace(argument), new ArgumentException($"String cannot be null, empty or white space. Argument description: {argumentDescription}"));
-        }
-
-        /// <summary>Throws an ArgumentException when an argument string of the list is null, empty or white spaces.</summary>
-        /// <param name="argumentDefinitions">Collection of argument definitions to validate. Each definition includes the argument's string value and description/name.</param>
-        public static void ArgumentStringNullOrWhiteSpace(params (string, string)[] argumentDefinitions)
-        {
-            foreach (var argDefinition in argumentDefinitions ?? Enumerable.Empty<(string, string)>())
-            {
-                ArgumentStringNullOrWhiteSpace(argDefinition.Item1, argDefinition.Item2);
-            }
+            ArgumentStringNullOrWhiteSpace(argDefinition.Item1, argDefinition.Item2);
         }
     }
 }

--- a/src/ToolPack.Exceptions.Base/ToolPack.Exceptions.Base.csproj
+++ b/src/ToolPack.Exceptions.Base/ToolPack.Exceptions.Base.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>true</IsPackable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -13,7 +13,7 @@
             Repo: https://github.com/nunohpinheiro/toolpack-exceptions
         </Description>
 
-        <PackageVersion>1.0.0</PackageVersion>
+        <PackageVersion>2.0.0</PackageVersion>
 
         <PackageId>ToolPack.Exceptions.Base</PackageId>
         <PackageProjectUrl>https://github.com/nunohpinheiro/toolpack-exceptions</PackageProjectUrl>
@@ -31,13 +31,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="10.2.3" />
-        <PackageReference Include="Grpc.AspNetCore.Server" Version="2.38.0" />
-        <PackageReference Include="Grpc.Core.Api" Version="2.38.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-        <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
+        <PackageReference Include="FluentValidation" Version="11.0.2" />
     </ItemGroup>
 
 </Project>

--- a/src/ToolPack.Exceptions.Web/Extensions/DependencyInjectionExtensions.cs
+++ b/src/ToolPack.Exceptions.Web/Extensions/DependencyInjectionExtensions.cs
@@ -1,71 +1,70 @@
-namespace ToolPack.Exceptions.Web.Extensions
+namespace ToolPack.Exceptions.Web.Extensions;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using ToolPack.Exceptions.Web.Handlers;
+using ToolPack.Exceptions.Web.Services.Implementations;
+using ToolPack.Exceptions.Web.Services.Interfaces;
+
+/// <summary>Class with extension methods to inject dependencies regarding the ToolPack Exceptions framework.</summary>
+public static class DependencyInjectionExtensions
 {
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.Extensions.DependencyInjection;
-    using ToolPack.Exceptions.Web.Handlers;
-    using ToolPack.Exceptions.Web.Services.Implementations;
-    using ToolPack.Exceptions.Web.Services.Interfaces;
-
-    /// <summary>Class with extension methods to inject dependencies regarding the ToolPack Exceptions framework.</summary>
-    public static class DependencyInjectionExtensions
+    /// <summary>
+    /// Adds the ToolPack Exceptions framework services that treat exceptions.
+    /// This does not include gRPC interceptors nor ASP.NET middleware (for such, see the other extension methods).</summary>
+    /// <param name="services">The services.</param>
+    /// <returns>The services updated with a registered Exceptions system.</returns>
+    public static IServiceCollection AddToolPackExceptions(this IServiceCollection services)
     {
-        /// <summary>
-        /// Adds the ToolPack Exceptions framework services that treat exceptions.
-        /// This does not include gRPC interceptors nor ASP.NET middleware (for such, see the other extension methods).</summary>
-        /// <param name="services">The services.</param>
-        /// <returns>The services updated with a registered Exceptions system.</returns>
-        public static IServiceCollection AddToolPackExceptions(this IServiceCollection services)
-        {
-            services.AddExceptionServices();
+        services.AddExceptionServices();
 
-            return services;
-        }
+        return services;
+    }
 
-        /// <summary>
-        /// Adds all the ToolPack Exceptions framework required for gRPC services, to handle exceptions globally in gRPC calls.
-        /// If handling exceptions in REST endpoints is required, proper middleware must be used (see extension "UseToolPackExceptionsMiddleware").</summary>
-        /// <param name="services">The services.</param>
-        /// <returns>The services updated with a registered Exceptions system (including gRPC interceptor services).</returns>
-        public static IServiceCollection AddToolPackExceptionsGrpc(this IServiceCollection services)
-        {
-            services.AddToolPackExceptions()
-                    .AddToolPackExceptionsGrpcInterceptor();
+    /// <summary>
+    /// Adds all the ToolPack Exceptions framework required for gRPC services, to handle exceptions globally in gRPC calls.
+    /// If handling exceptions in REST endpoints is required, proper middleware must be used (see extension "UseToolPackExceptionsMiddleware").</summary>
+    /// <param name="services">The services.</param>
+    /// <returns>The services updated with a registered Exceptions system (including gRPC interceptor services).</returns>
+    public static IServiceCollection AddToolPackExceptionsGrpc(this IServiceCollection services)
+    {
+        services.AddToolPackExceptions()
+                .AddToolPackExceptionsGrpcInterceptor();
 
-            return services;
-        }
+        return services;
+    }
 
-        /// <summary>
-        /// Adds the ToolPack Exceptions interceptor services, to handle exceptions globally in gRPC calls.
-        /// It must not be used in REST APIs; in such cases, exceptions must be handled with proper middleware (see extension "UseToolPackExceptionsMiddleware").
-        /// It does not add the ToolPack Exceptions framework services that treat exceptions; for such, use "AddToolPackExceptionsGrpc" or "AddToolPackExceptions".</summary>
-        /// <param name="services">The services.</param>
-        /// <returns>The gRPC builder updated with the registered interceptor services.</returns>
-        public static IServiceCollection AddToolPackExceptionsGrpcInterceptor(this IServiceCollection services)
-        {
-            services.AddGrpc(options => options.Interceptors.Add<GlobalExceptionInterceptor>());
+    /// <summary>
+    /// Adds the ToolPack Exceptions interceptor services, to handle exceptions globally in gRPC calls.
+    /// It must not be used in REST APIs; in such cases, exceptions must be handled with proper middleware (see extension "UseToolPackExceptionsMiddleware").
+    /// It does not add the ToolPack Exceptions framework services that treat exceptions; for such, use "AddToolPackExceptionsGrpc" or "AddToolPackExceptions".</summary>
+    /// <param name="services">The services.</param>
+    /// <returns>The gRPC builder updated with the registered interceptor services.</returns>
+    public static IServiceCollection AddToolPackExceptionsGrpcInterceptor(this IServiceCollection services)
+    {
+        services.AddGrpc(options => options.Interceptors.Add<GlobalExceptionInterceptor>());
 
-            return services;
-        }
+        return services;
+    }
 
-        /// <summary>
-        /// Uses the ToolPack Exceptions middleware, to handle exceptions globally in the request pipeline.
-        /// It must not be used in gRPC APIs; in such cases, exceptions must be handled with interceptors (see extensions "AddToolPackExceptionsGrpc" and "AddToolPackExceptionsGrpcInterceptor").
-        /// It does not add the ToolPack Exceptions framework services that treat exceptions, so the extension "AddToolPackExceptions" must also be used.</summary>
-        /// <param name="appBuilder">The application builder.</param>
-        /// <returns>The application builder updated with the registered middleware.</returns>
-        public static IApplicationBuilder UseToolPackExceptionsMiddleware(this IApplicationBuilder appBuilder)
-        {
-            appBuilder.UseMiddleware<GlobalExceptionMiddleware>();
+    /// <summary>
+    /// Uses the ToolPack Exceptions middleware, to handle exceptions globally in the request pipeline.
+    /// It must not be used in gRPC APIs; in such cases, exceptions must be handled with interceptors (see extensions "AddToolPackExceptionsGrpc" and "AddToolPackExceptionsGrpcInterceptor").
+    /// It does not add the ToolPack Exceptions framework services that treat exceptions, so the extension "AddToolPackExceptions" must also be used.</summary>
+    /// <param name="appBuilder">The application builder.</param>
+    /// <returns>The application builder updated with the registered middleware.</returns>
+    public static IApplicationBuilder UseToolPackExceptionsMiddleware(this IApplicationBuilder appBuilder)
+    {
+        appBuilder.UseMiddleware<GlobalExceptionMiddleware>();
 
-            return appBuilder;
-        }
+        return appBuilder;
+    }
 
-        private static IServiceCollection AddExceptionServices(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor()
-                    .AddScoped<IProblemDetailsService, ProblemDetailsService>();
+    private static IServiceCollection AddExceptionServices(this IServiceCollection services)
+    {
+        services.AddHttpContextAccessor()
+                .AddScoped<IProblemDetailsService, ProblemDetailsService>();
 
-            return services;
-        }
+        return services;
     }
 }

--- a/src/ToolPack.Exceptions.Web/Extensions/JsonExtensions.cs
+++ b/src/ToolPack.Exceptions.Web/Extensions/JsonExtensions.cs
@@ -1,30 +1,29 @@
-namespace ToolPack.Exceptions.Web.Extensions
-{
-    using System;
-    using System.Text.Json;
+namespace ToolPack.Exceptions.Web.Extensions;
 
-    internal static class JsonExtensions
+using System;
+using System.Text.Json;
+
+internal static class JsonExtensions
+{
+    /// <summary>Tries to serialize an object to JSON, using camel case.</summary>
+    /// <typeparam name="T">The type of the input object.</typeparam>
+    /// <param name="inputObject">The input object to be serialized.</param>
+    /// <param name="outputJson">The output JSON string representation of the object. If the serialization fails, it will be null.</param>
+    /// <param name="exception">The occurring exception, when the serialization fails. Otherwise, it will be null.</param>
+    /// <returns>True, if the serialization succeeds; otherwise, false.</returns>
+    internal static bool TrySerializeCamelCase<T>(this T inputObject, out string outputJson, out Exception exception)
     {
-        /// <summary>Tries to serialize an object to JSON, using camel case.</summary>
-        /// <typeparam name="T">The type of the input object.</typeparam>
-        /// <param name="inputObject">The input object to be serialized.</param>
-        /// <param name="outputJson">The output JSON string representation of the object. If the serialization fails, it will be null.</param>
-        /// <param name="exception">The occurring exception, when the serialization fails. Otherwise, it will be null.</param>
-        /// <returns>True, if the serialization succeeds; otherwise, false.</returns>
-        internal static bool TrySerializeCamelCase<T>(this T inputObject, out string outputJson, out Exception exception)
+        outputJson = null;
+        exception = null;
+        try
         {
-            outputJson = null;
-            exception = null;
-            try
-            {
-                outputJson = JsonSerializer.Serialize(inputObject, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-                return true;
-            }
-            catch (Exception ex)
-            {
-                exception = ex;
-                return false;
-            }
+            outputJson = JsonSerializer.Serialize(inputObject, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            return true;
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+            return false;
         }
     }
 }

--- a/src/ToolPack.Exceptions.Web/Handlers/GlobalExceptionInterceptor.cs
+++ b/src/ToolPack.Exceptions.Web/Handlers/GlobalExceptionInterceptor.cs
@@ -1,114 +1,113 @@
-namespace ToolPack.Exceptions.Web.Handlers
+namespace ToolPack.Exceptions.Web.Handlers;
+
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+using ToolPack.Exceptions.Web.Services.Interfaces;
+
+/// <summary>
+/// Interceptor to handle exceptions in gRPC services globally.
+/// </summary>
+internal class GlobalExceptionInterceptor : Interceptor
 {
-    using Grpc.Core;
-    using Grpc.Core.Interceptors;
-    using Microsoft.Extensions.Logging;
-    using System;
-    using System.Threading.Tasks;
-    using ToolPack.Exceptions.Web.Services.Interfaces;
+    private readonly ILogger<GlobalExceptionInterceptor> _logger;
+    private readonly IProblemDetailsService _problemDetailsService;
 
-    /// <summary>
-    /// Interceptor to handle exceptions in gRPC services globally.
-    /// </summary>
-    internal class GlobalExceptionInterceptor : Interceptor
+    public GlobalExceptionInterceptor(
+        ILogger<GlobalExceptionInterceptor> logger,
+        IProblemDetailsService problemDetailsService)
     {
-        private readonly ILogger<GlobalExceptionInterceptor> _logger;
-        private readonly IProblemDetailsService _problemDetailsService;
+        _logger = logger;
+        _problemDetailsService = problemDetailsService;
+    }
 
-        public GlobalExceptionInterceptor(
-            ILogger<GlobalExceptionInterceptor> logger,
-            IProblemDetailsService problemDetailsService)
+    public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        ServerCallContext context,
+        ClientStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("Incoming request in GlobalExceptionInterceptor - client streaming server handler.");
+        try
         {
-            _logger = logger;
-            _problemDetailsService = problemDetailsService;
+            return await continuation(requestStream, context);
         }
-
-        public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
-            IAsyncStreamReader<TRequest> requestStream,
-            ServerCallContext context,
-            ClientStreamingServerMethod<TRequest, TResponse> continuation)
+        catch (Exception ex)
         {
-            _logger.LogInformation("Incoming request in GlobalExceptionInterceptor - client streaming server handler.");
-            try
-            {
-                return await continuation(requestStream, context);
-            }
-            catch (Exception ex)
-            {
-                throw HandleException(context, ex);
-            }
+            throw HandleException(context, ex);
         }
+    }
 
-        public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(
-            IAsyncStreamReader<TRequest> requestStream,
-            IServerStreamWriter<TResponse> responseStream,
-            ServerCallContext context,
-            DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+    public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("Incoming request in GlobalExceptionInterceptor - duplex streaming server handler.");
+        try
         {
-            _logger.LogInformation("Incoming request in GlobalExceptionInterceptor - duplex streaming server handler.");
-            try
-            {
-                await continuation(requestStream, responseStream, context);
-            }
-            catch (Exception ex)
-            {
-                throw HandleException(context, ex);
-            }
+            await continuation(requestStream, responseStream, context);
         }
-
-        public override async Task ServerStreamingServerHandler<TRequest, TResponse>(
-            TRequest request,
-            IServerStreamWriter<TResponse> responseStream,
-            ServerCallContext context,
-            ServerStreamingServerMethod<TRequest, TResponse> continuation)
+        catch (Exception ex)
         {
-            _logger.LogInformation("Incoming request in GlobalExceptionInterceptor - server streaming server handler.");
-            try
-            {
-                await continuation(request, responseStream, context);
-            }
-            catch (Exception ex)
-            {
-                throw HandleException(context, ex);
-            }
+            throw HandleException(context, ex);
         }
+    }
 
-        public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
-            TRequest request,
-            ServerCallContext context,
-            UnaryServerMethod<TRequest, TResponse> continuation)
+    public override async Task ServerStreamingServerHandler<TRequest, TResponse>(
+        TRequest request,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        ServerStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("Incoming request in GlobalExceptionInterceptor - server streaming server handler.");
+        try
         {
-            _logger.LogInformation("Incoming request in GlobalExceptionInterceptor - unary server handler.");
-            try
-            {
-                return await continuation(request, context);
-            }
-            catch (Exception ex)
-            {
-                throw HandleException(context, ex);
-            }
+            await continuation(request, responseStream, context);
         }
-
-        private RpcException HandleException(ServerCallContext context, Exception ex)
+        catch (Exception ex)
         {
-            _logger.LogError(
-                    "An exception was caught by the GlobalExceptionInterceptor. Context method: {ContextMethod} | Exception: {Exception}",
-                    context.Method,
-                    ex);
-
-            return GetProblemDetailsRpcException(ex);
+            throw HandleException(context, ex);
         }
+    }
 
-        private RpcException GetProblemDetailsRpcException(Exception ex)
+    public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        _logger.LogInformation("Incoming request in GlobalExceptionInterceptor - unary server handler.");
+        try
         {
-            var (problemDetailsResponse, errorStatus) = _problemDetailsService.BuildProblemDetailsResponse(ex);
-
-            _logger.LogInformation(
-                "A ProblemDetails response was built with error status. ErrorStatus: {ErrorStatus} | ProblemDetails: {ProblemDetails}",
-                errorStatus,
-                problemDetailsResponse);
-
-            return new RpcException(new Status(errorStatus.GrpcCode, problemDetailsResponse), problemDetailsResponse);
+            return await continuation(request, context);
         }
+        catch (Exception ex)
+        {
+            throw HandleException(context, ex);
+        }
+    }
+
+    private RpcException HandleException(ServerCallContext context, Exception ex)
+    {
+        _logger.LogError(
+                "An exception was caught by the GlobalExceptionInterceptor. Context method: {ContextMethod} | Exception: {Exception}",
+                context.Method,
+                ex);
+
+        return GetProblemDetailsRpcException(ex);
+    }
+
+    private RpcException GetProblemDetailsRpcException(Exception ex)
+    {
+        var (problemDetailsResponse, errorStatus) = _problemDetailsService.BuildProblemDetailsResponse(ex);
+
+        _logger.LogInformation(
+            "A ProblemDetails response was built with error status. ErrorStatus: {ErrorStatus} | ProblemDetails: {ProblemDetails}",
+            errorStatus,
+            problemDetailsResponse);
+
+        return new RpcException(new Status(errorStatus.GrpcCode, problemDetailsResponse), problemDetailsResponse);
     }
 }

--- a/src/ToolPack.Exceptions.Web/Handlers/GlobalExceptionMiddleware.cs
+++ b/src/ToolPack.Exceptions.Web/Handlers/GlobalExceptionMiddleware.cs
@@ -2,62 +2,61 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ToolPack.Exceptions.UnitTests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-namespace ToolPack.Exceptions.Web.Handlers
+namespace ToolPack.Exceptions.Web.Handlers;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using ToolPack.Exceptions.Web.Services.Interfaces;
+
+/// <summary>
+/// Middleware to handle exceptions in ASP.NET REST services globally.
+/// </summary>
+internal class GlobalExceptionMiddleware
 {
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Logging;
-    using System;
-    using System.Net.Mime;
-    using System.Threading.Tasks;
-    using ToolPack.Exceptions.Web.Services.Interfaces;
+    private readonly ILogger<GlobalExceptionMiddleware> _logger;
+    private readonly RequestDelegate _next;
 
-    /// <summary>
-    /// Middleware to handle exceptions in ASP.NET REST services globally.
-    /// </summary>
-    internal class GlobalExceptionMiddleware
+    public GlobalExceptionMiddleware(
+        ILogger<GlobalExceptionMiddleware> logger,
+        RequestDelegate next)
     {
-        private readonly ILogger<GlobalExceptionMiddleware> _logger;
-        private readonly RequestDelegate _next;
+        _logger = logger;
+        _next = next;
+    }
 
-        public GlobalExceptionMiddleware(
-            ILogger<GlobalExceptionMiddleware> logger,
-            RequestDelegate next)
+    public async Task InvokeAsync(HttpContext httpContext, IProblemDetailsService problemDetailsService)
+    {
+        _logger.LogInformation("Incoming request in GlobalExceptionMiddleware.");
+
+        try
         {
-            _logger = logger;
-            _next = next;
+            await _next(httpContext);
         }
-
-        public async Task InvokeAsync(HttpContext httpContext, IProblemDetailsService problemDetailsService)
+        catch (Exception ex)
         {
-            _logger.LogInformation("Incoming request in GlobalExceptionMiddleware.");
-
-            try
-            {
-                await _next(httpContext);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("An exception was caught by the GlobalExceptionMiddleware. Exception: {Exception}", ex);
-                await HandleExceptionAsync(httpContext, problemDetailsService, ex);
-            }
+            _logger.LogError("An exception was caught by the GlobalExceptionMiddleware. Exception: {Exception}", ex);
+            await HandleExceptionAsync(httpContext, problemDetailsService, ex);
         }
+    }
 
-        private async Task HandleExceptionAsync(HttpContext httpContext, IProblemDetailsService problemDetailsService, Exception ex)
+    private async Task HandleExceptionAsync(HttpContext httpContext, IProblemDetailsService problemDetailsService, Exception ex)
+    {
+        var (problemDetailsResponse, errorStatus) = problemDetailsService.BuildProblemDetailsResponse(ex);
+
+        _logger.LogInformation(
+            "A ProblemDetails response was built with error status. ErrorStatus: {ErrorStatus} | ProblemDetails: {ProblemDetails}",
+            errorStatus,
+            problemDetailsResponse);
+
+        if (httpContext?.Response is not null)
         {
-            var (problemDetailsResponse, errorStatus) = problemDetailsService.BuildProblemDetailsResponse(ex);
-
-            _logger.LogInformation(
-                "A ProblemDetails response was built with error status. ErrorStatus: {ErrorStatus} | ProblemDetails: {ProblemDetails}",
-                errorStatus,
-                problemDetailsResponse);
-
-            if (httpContext?.Response is not null)
-            {
-                httpContext.Response.ContentType = MediaTypeNames.Application.Json;
-                httpContext.Response.StatusCode = (int)errorStatus.HttpCode;
-                await httpContext.Response.WriteAsync(problemDetailsResponse);
-            }
-            return;
+            httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+            httpContext.Response.StatusCode = (int)errorStatus.HttpCode;
+            await httpContext.Response.WriteAsync(problemDetailsResponse);
         }
+        return;
     }
 }

--- a/src/ToolPack.Exceptions.Web/Models/ProblemDetails.cs
+++ b/src/ToolPack.Exceptions.Web/Models/ProblemDetails.cs
@@ -1,103 +1,102 @@
-namespace ToolPack.Exceptions.Web.Models
+namespace ToolPack.Exceptions.Web.Models;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ToolPack.Exceptions.Base.Entities;
+
+/// <summary>
+/// Problem Details entity that extends the one in AspNetCore.Mvc (https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.problemdetails).
+/// Used to return application problems, using the RFC 7807 (https://tools.ietf.org/html/rfc7807).
+/// </summary>
+public class ProblemDetails : Microsoft.AspNetCore.Mvc.ProblemDetails
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using ToolPack.Exceptions.Base.Entities;
+    /// <summary>Gets or sets additional errors related with the Problem Details.</summary>
+    public IDictionary<string, string[]> Errors { get; private set; }
 
-    /// <summary>
-    /// Problem Details entity that extends the one in AspNetCore.Mvc (https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.problemdetails).
-    /// Used to return application problems, using the RFC 7807 (https://tools.ietf.org/html/rfc7807).
-    /// </summary>
-    public class ProblemDetails : Microsoft.AspNetCore.Mvc.ProblemDetails
+    /// <summary>Tracing identifier related with the context of these ProblemDetails.</summary>
+    public string TraceId { get; init; }
+
+    /// <summary>Creates a ProblemDetails instance with properties derived from a given exception.</summary>
+    /// <param name="exception">Exception from which the ProblemDetails properties are filled.</param>
+    public ProblemDetails(Exception exception)
     {
-        /// <summary>Gets or sets additional errors related with the Problem Details.</summary>
-        public IDictionary<string, string[]> Errors { get; private set; }
+        var exceptionErrorStatus = WebErrorStatuses.GetFromException(exception);
 
-        /// <summary>Tracing identifier related with the context of these ProblemDetails.</summary>
-        public string TraceId { get; init; }
+        Detail = exception?.Message;
+        Instance = exceptionErrorStatus.Description;
+        Status = (int)exceptionErrorStatus.HttpCode;
+        Title = exceptionErrorStatus.HttpCode.ToString();
+        Type = exceptionErrorStatus.Description;
 
-        /// <summary>Creates a ProblemDetails instance with properties derived from a given exception.</summary>
-        /// <param name="exception">Exception from which the ProblemDetails properties are filled.</param>
-        public ProblemDetails(Exception exception)
+        SetErrors(exception);
+    }
+
+    /// <summary>Creates a ProblemDetails instance with properties derived from a given exception.</summary>
+    /// <param name="exception">Exception from which the ProblemDetails properties are filled.</param>
+    /// <param name="traceId">Tracing identifier related with the context of this ProblemDetails.</param>
+    public ProblemDetails(Exception exception, string traceId)
+        : this(exception)
+    {
+        TraceId = traceId;
+    }
+
+    /// <summary>Creates a default ProblemDetails instance.</summary>
+    /// <param name="traceId">Tracing identifier related with the context of these ProblemDetails.</param>
+    public ProblemDetails(string traceId)
+    {
+        var problemDetailsStatus = WebErrorStatuses.InternalUnknownError;
+
+        Detail = problemDetailsStatus.HttpCode.ToString();
+        Status = (int)problemDetailsStatus.HttpCode;
+        Title = problemDetailsStatus.HttpCode.ToString();
+        TraceId = traceId;
+        Type = problemDetailsStatus.Description;
+    }
+
+    private void SetErrors(Exception exception)
+    {
+        if (exception is null)
+            return;
+
+        if (exception is AggregateException aggregateException)
+            SetErrorsFromAggregateException(aggregateException);
+
+        else if ((exception is ValidationFailedException validationException) && validationException.Errors.Any())
+            Errors = validationException.Errors;
+
+        else if (exception.InnerException is not null)
+            SetErrorsFromInnerException(exception.InnerException);
+    }
+
+    private void SetErrorsFromAggregateException(AggregateException exception)
+    {
+        var failureGroups = exception?.InnerExceptions?.GroupBy(
+                                e => string.IsNullOrWhiteSpace(e.Source) ? "UnknownSource" : e.Source,
+                                e => e.Message);
+
+        if (failureGroups?.Any() is not true)
+            return;
+
+        Errors = new Dictionary<string, string[]>();
+
+        foreach (var failureGroup in failureGroups)
         {
-            var exceptionErrorStatus = WebErrorStatuses.GetFromException(exception);
+            var propertyName = failureGroup.Key;
+            var propertyFailures = failureGroup.ToArray();
 
-            Detail = exception?.Message;
-            Instance = exceptionErrorStatus.Description;
-            Status = (int)exceptionErrorStatus.HttpCode;
-            Title = exceptionErrorStatus.HttpCode.ToString();
-            Type = exceptionErrorStatus.Description;
-
-            SetErrors(exception);
+            Errors.Add(propertyName, propertyFailures);
         }
+    }
 
-        /// <summary>Creates a ProblemDetails instance with properties derived from a given exception.</summary>
-        /// <param name="exception">Exception from which the ProblemDetails properties are filled.</param>
-        /// <param name="traceId">Tracing identifier related with the context of this ProblemDetails.</param>
-        public ProblemDetails(Exception exception, string traceId)
-            : this(exception)
+    private void SetErrorsFromInnerException(Exception innerException)
+    {
+        Errors = new Dictionary<string, string[]>
         {
-            TraceId = traceId;
-        }
-
-        /// <summary>Creates a default ProblemDetails instance.</summary>
-        /// <param name="traceId">Tracing identifier related with the context of these ProblemDetails.</param>
-        public ProblemDetails(string traceId)
-        {
-            var problemDetailsStatus = WebErrorStatuses.InternalUnknownError;
-
-            Detail = problemDetailsStatus.HttpCode.ToString();
-            Status = (int)problemDetailsStatus.HttpCode;
-            Title = problemDetailsStatus.HttpCode.ToString();
-            TraceId = traceId;
-            Type = problemDetailsStatus.Description;
-        }
-
-        private void SetErrors(Exception exception)
-        {
-            if (exception is null)
-                return;
-
-            if (exception is AggregateException aggregateException)
-                SetErrorsFromAggregateException(aggregateException);
-
-            else if ((exception is ValidationFailedException validationException) && validationException.Errors.Any())
-                Errors = validationException.Errors;
-
-            else if (exception.InnerException is not null)
-                SetErrorsFromInnerException(exception.InnerException);
-        }
-
-        private void SetErrorsFromAggregateException(AggregateException exception)
-        {
-            var failureGroups = exception?.InnerExceptions?.GroupBy(
-                                    e => string.IsNullOrWhiteSpace(e.Source) ? "UnknownSource" : e.Source,
-                                    e => e.Message);
-
-            if (failureGroups?.Any() is not true)
-                return;
-
-            Errors = new Dictionary<string, string[]>();
-
-            foreach (var failureGroup in failureGroups)
             {
-                var propertyName = failureGroup.Key;
-                var propertyFailures = failureGroup.ToArray();
-
-                Errors.Add(propertyName, propertyFailures);
+                string.IsNullOrWhiteSpace(innerException.Source) ? "UnknownSource" : innerException.Source,
+                new string[1] { innerException.Message }
             }
-        }
-
-        private void SetErrorsFromInnerException(Exception innerException)
-        {
-            Errors = new Dictionary<string, string[]>
-            {
-                {
-                    string.IsNullOrWhiteSpace(innerException.Source) ? "UnknownSource" : innerException.Source,
-                    new string[1] { innerException.Message }
-                }
-            };
-        }
+        };
     }
 }

--- a/src/ToolPack.Exceptions.Web/Models/ProblemDetailsWebResponse.cs
+++ b/src/ToolPack.Exceptions.Web/Models/ProblemDetailsWebResponse.cs
@@ -1,19 +1,18 @@
-namespace ToolPack.Exceptions.Web.Models
+namespace ToolPack.Exceptions.Web.Models;
+
+using System;
+
+internal class ProblemDetailsWebResponse
 {
-    using System;
+    internal ProblemDetails ProblemDetails { get; init; }
+    internal WebErrorStatus WebErrorStatus { get; init; }
 
-    internal class ProblemDetailsWebResponse
+    /// <summary>Creates a ProblemDetailsWebResponse instance with properties derived from a given exception.</summary>
+    /// <param name="exception">Exception from which the ProblemDetails and WebErrorStatus properties are constructed.</param>
+    /// <param name="traceId">Tracing identifier related with the context of the ProblemDetails property.</param>
+    internal ProblemDetailsWebResponse(Exception exception, string traceId)
     {
-        internal ProblemDetails ProblemDetails { get; init; }
-        internal WebErrorStatus WebErrorStatus { get; init; }
-
-        /// <summary>Creates a ProblemDetailsWebResponse instance with properties derived from a given exception.</summary>
-        /// <param name="exception">Exception from which the ProblemDetails and WebErrorStatus properties are constructed.</param>
-        /// <param name="traceId">Tracing identifier related with the context of the ProblemDetails property.</param>
-        internal ProblemDetailsWebResponse(Exception exception, string traceId)
-        {
-            ProblemDetails = new(exception, traceId);
-            WebErrorStatus = WebErrorStatuses.GetFromException(exception);
-        }
+        ProblemDetails = new(exception, traceId);
+        WebErrorStatus = WebErrorStatuses.GetFromException(exception);
     }
 }

--- a/src/ToolPack.Exceptions.Web/Models/WebErrorStatus.cs
+++ b/src/ToolPack.Exceptions.Web/Models/WebErrorStatus.cs
@@ -1,26 +1,25 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ToolPack.Exceptions.UnitTests")]
-namespace ToolPack.Exceptions.Web.Models
+namespace ToolPack.Exceptions.Web.Models;
+
+using Grpc.Core;
+using System.Net;
+
+/// <summary>Placeholder that relates HTTP and gRPC Status Codes with a common description.</summary>
+public record WebErrorStatus
 {
-    using Grpc.Core;
-    using System.Net;
+    internal StatusCode GrpcCode { get; init; }
+    internal HttpStatusCode HttpCode { get; init; }
+    internal string Description { get; init; }
 
-    /// <summary>Placeholder that relates HTTP and gRPC Status Codes with a common description.</summary>
-    public record WebErrorStatus
+    internal WebErrorStatus(
+        StatusCode grpcCode,
+        HttpStatusCode httpCode,
+        string typeDescription)
     {
-        internal StatusCode GrpcCode { get; init; }
-        internal HttpStatusCode HttpCode { get; init; }
-        internal string Description { get; init; }
-
-        internal WebErrorStatus(
-            StatusCode grpcCode,
-            HttpStatusCode httpCode,
-            string typeDescription)
-        {
-            GrpcCode = grpcCode;
-            HttpCode = httpCode;
-            Description = typeDescription;
-        }
+        GrpcCode = grpcCode;
+        HttpCode = httpCode;
+        Description = typeDescription;
     }
 }

--- a/src/ToolPack.Exceptions.Web/Models/WebErrorStatuses.cs
+++ b/src/ToolPack.Exceptions.Web/Models/WebErrorStatuses.cs
@@ -1,112 +1,111 @@
-namespace ToolPack.Exceptions.Web.Models
+namespace ToolPack.Exceptions.Web.Models;
+
+using Grpc.Core;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Security.Authentication;
+using System.Threading.Tasks;
+using ToolPack.Exceptions.Base.Entities;
+
+/// <summary>
+/// Opiniated Error Statuses relating error types according to their meaning in the Web (HTTP and gRPC status codes).
+/// This also relates the Error Statuses with known types of Exceptions - both custom and generic.
+/// </summary>
+public static class WebErrorStatuses
 {
-    using Grpc.Core;
-    using System;
-    using System.Net;
-    using System.Net.Http;
-    using System.Security.Authentication;
-    using System.Threading.Tasks;
-    using ToolPack.Exceptions.Base.Entities;
+    /// <summary>Entity already exists.</summary>
+    public static readonly WebErrorStatus AlreadyExists =
+        new(StatusCode.AlreadyExists, HttpStatusCode.Conflict, "Entity already exists.");
 
-    /// <summary>
-    /// Opiniated Error Statuses relating error types according to their meaning in the Web (HTTP and gRPC status codes).
-    /// This also relates the Error Statuses with known types of Exceptions - both custom and generic.
-    /// </summary>
-    public static class WebErrorStatuses
+    /// <summary>Argument is incorrect.</summary>
+    public static readonly WebErrorStatus ArgumentError =
+        new(StatusCode.InvalidArgument, HttpStatusCode.BadRequest, "Argument is incorrect.");
+
+    /// <summary>Underlying dependency failed.</summary>
+    public static readonly WebErrorStatus FailedDependency =
+        new(StatusCode.Internal, HttpStatusCode.FailedDependency, "Underlying component on which the system depends failed.");
+
+    /// <summary>Permission to operation is not granted.</summary>
+    public static readonly WebErrorStatus ForbiddenPermission =
+        new(StatusCode.PermissionDenied, HttpStatusCode.Forbidden, "Permission to operation is not granted.");
+
+    /// <summary>An internal error in the system.</summary>
+    public static readonly WebErrorStatus InternalError =
+        new(StatusCode.Internal, HttpStatusCode.InternalServerError, "An internal error occurred.");
+
+    /// <summary>An internal unknown error in the system.</summary>
+    public static readonly WebErrorStatus InternalUnknownError =
+        new(StatusCode.Unknown, HttpStatusCode.InternalServerError, "An internal unknown error occurred.");
+
+    /// <summary>Entity not found.</summary>
+    public static readonly WebErrorStatus NotFound =
+        new(StatusCode.NotFound, HttpStatusCode.NotFound, "Entity not found.");
+
+    /// <summary>Operation is not supported.</summary>
+    public static readonly WebErrorStatus NotImplemented =
+        new(StatusCode.Unimplemented, HttpStatusCode.NotImplemented, "Operation is not supported.");
+
+    /// <summary>Precondition required to operation failed.</summary>
+    public static readonly WebErrorStatus PreconditionFailed =
+        new(StatusCode.FailedPrecondition, HttpStatusCode.BadRequest, "Precondition required to operation failed.");
+
+    /// <summary>Operation was cancelled.</summary>
+    public static readonly WebErrorStatus RequestCancelled =
+        new(StatusCode.Cancelled, HttpStatusCode.BadRequest, "Operation was cancelled.");
+
+    /// <summary>Operation timed out.</summary>
+    public static readonly WebErrorStatus Timeout =
+        new(StatusCode.DeadlineExceeded, HttpStatusCode.GatewayTimeout, "Operation timed out.");
+
+    /// <summary>Required authentication is absent.</summary>
+    public static readonly WebErrorStatus Unauthenticated =
+        new(StatusCode.Unauthenticated, HttpStatusCode.Unauthorized, "Required authentication is absent.");
+
+    /// <summary>Service is not available.</summary>
+    public static readonly WebErrorStatus UnavailableError =
+        new(StatusCode.Unavailable, HttpStatusCode.ServiceUnavailable, "Service is not available.");
+
+    /// <summary>Gets a web error status according to the given exception type.</summary>
+    /// <typeparam name="T">The exception type.</typeparam>
+    /// <param name="exception">The exception.</param>
+    /// <returns>An instance of WebErrorStatus, matching the given exception.</returns>
+    public static WebErrorStatus GetFromException<T>(T exception)
+        where T : Exception
     {
-        /// <summary>Entity already exists.</summary>
-        public static readonly WebErrorStatus AlreadyExists =
-            new(StatusCode.AlreadyExists, HttpStatusCode.Conflict, "Entity already exists.");
-
-        /// <summary>Argument is incorrect.</summary>
-        public static readonly WebErrorStatus ArgumentError =
-            new(StatusCode.InvalidArgument, HttpStatusCode.BadRequest, "Argument is incorrect.");
-
-        /// <summary>Underlying dependency failed.</summary>
-        public static readonly WebErrorStatus FailedDependency =
-            new(StatusCode.Internal, HttpStatusCode.FailedDependency, "Underlying component on which the system depends failed.");
-
-        /// <summary>Permission to operation is not granted.</summary>
-        public static readonly WebErrorStatus ForbiddenPermission =
-            new(StatusCode.PermissionDenied, HttpStatusCode.Forbidden, "Permission to operation is not granted.");
-
-        /// <summary>An internal error in the system.</summary>
-        public static readonly WebErrorStatus InternalError =
-            new(StatusCode.Internal, HttpStatusCode.InternalServerError, "An internal error occurred.");
-
-        /// <summary>An internal unknown error in the system.</summary>
-        public static readonly WebErrorStatus InternalUnknownError =
-            new(StatusCode.Unknown, HttpStatusCode.InternalServerError, "An internal unknown error occurred.");
-
-        /// <summary>Entity not found.</summary>
-        public static readonly WebErrorStatus NotFound =
-            new(StatusCode.NotFound, HttpStatusCode.NotFound, "Entity not found.");
-
-        /// <summary>Operation is not supported.</summary>
-        public static readonly WebErrorStatus NotImplemented =
-            new(StatusCode.Unimplemented, HttpStatusCode.NotImplemented, "Operation is not supported.");
-
-        /// <summary>Precondition required to operation failed.</summary>
-        public static readonly WebErrorStatus PreconditionFailed =
-            new(StatusCode.FailedPrecondition, HttpStatusCode.BadRequest, "Precondition required to operation failed.");
-
-        /// <summary>Operation was cancelled.</summary>
-        public static readonly WebErrorStatus RequestCancelled =
-            new(StatusCode.Cancelled, HttpStatusCode.BadRequest, "Operation was cancelled.");
-
-        /// <summary>Operation timed out.</summary>
-        public static readonly WebErrorStatus Timeout =
-            new(StatusCode.DeadlineExceeded, HttpStatusCode.GatewayTimeout, "Operation timed out.");
-
-        /// <summary>Required authentication is absent.</summary>
-        public static readonly WebErrorStatus Unauthenticated =
-            new(StatusCode.Unauthenticated, HttpStatusCode.Unauthorized, "Required authentication is absent.");
-
-        /// <summary>Service is not available.</summary>
-        public static readonly WebErrorStatus UnavailableError =
-            new(StatusCode.Unavailable, HttpStatusCode.ServiceUnavailable, "Service is not available.");
-
-        /// <summary>Gets a web error status according to the given exception type.</summary>
-        /// <typeparam name="T">The exception type.</typeparam>
-        /// <param name="exception">The exception.</param>
-        /// <returns>An instance of WebErrorStatus, matching the given exception.</returns>
-        public static WebErrorStatus GetFromException<T>(T exception)
-            where T : Exception
+        return exception switch
         {
-            return exception switch
-            {
-                CustomBaseException customException => GetFromCustomBaseException(customException),
-                _ => GetFromSystemException(exception),
-            };
-        }
+            CustomBaseException customException => GetFromCustomBaseException(customException),
+            _ => GetFromSystemException(exception),
+        };
+    }
 
-        private static WebErrorStatus GetFromCustomBaseException<T>(T exception)
-            where T : CustomBaseException
+    private static WebErrorStatus GetFromCustomBaseException<T>(T exception)
+        where T : CustomBaseException
+    {
+        return exception switch
         {
-            return exception switch
-            {
-                AlreadyExistsException => AlreadyExists,
-                ExternalComponentException => FailedDependency,
-                NotFoundException => NotFound,
-                ValidationFailedException => PreconditionFailed,
-                _ => InternalError
-            };
-        }
+            AlreadyExistsException => AlreadyExists,
+            ExternalComponentException => FailedDependency,
+            NotFoundException => NotFound,
+            ValidationFailedException => PreconditionFailed,
+            _ => InternalError
+        };
+    }
 
-        private static WebErrorStatus GetFromSystemException<T>(T exception)
-            where T : Exception
+    private static WebErrorStatus GetFromSystemException<T>(T exception)
+        where T : Exception
+    {
+        return exception switch
         {
-            return exception switch
-            {
-                ArgumentException => ArgumentError,
-                AuthenticationException => Unauthenticated,
-                HttpRequestException => UnavailableError,
-                NotImplementedException => NotImplemented,
-                TaskCanceledException => RequestCancelled,
-                TimeoutException => Timeout,
-                UnauthorizedAccessException => ForbiddenPermission,
-                _ => InternalUnknownError
-            };
-        }
+            ArgumentException => ArgumentError,
+            AuthenticationException => Unauthenticated,
+            HttpRequestException => UnavailableError,
+            NotImplementedException => NotImplemented,
+            TaskCanceledException => RequestCancelled,
+            TimeoutException => Timeout,
+            UnauthorizedAccessException => ForbiddenPermission,
+            _ => InternalUnknownError
+        };
     }
 }

--- a/src/ToolPack.Exceptions.Web/Services/Implementations/ProblemDetailsService.cs
+++ b/src/ToolPack.Exceptions.Web/Services/Implementations/ProblemDetailsService.cs
@@ -1,74 +1,73 @@
-namespace ToolPack.Exceptions.Web.Services.Implementations
+namespace ToolPack.Exceptions.Web.Services.Implementations;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using ToolPack.Exceptions.Web.Extensions;
+using ToolPack.Exceptions.Web.Models;
+using ToolPack.Exceptions.Web.Services.Interfaces;
+
+internal class ProblemDetailsService : IProblemDetailsService
 {
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Logging;
-    using System;
-    using System.Diagnostics;
-    using ToolPack.Exceptions.Web.Extensions;
-    using ToolPack.Exceptions.Web.Models;
-    using ToolPack.Exceptions.Web.Services.Interfaces;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<ProblemDetailsService> _logger;
 
-    internal class ProblemDetailsService : IProblemDetailsService
+    public ProblemDetailsService(
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<ProblemDetailsService> logger)
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly ILogger<ProblemDetailsService> _logger;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
 
-        public ProblemDetailsService(
-            IHttpContextAccessor httpContextAccessor,
-            ILogger<ProblemDetailsService> logger)
+    public (string, WebErrorStatus) BuildProblemDetailsResponse(Exception exception)
+    {
+        if (exception is null)
         {
-            _httpContextAccessor = httpContextAccessor;
-            _logger = logger;
+            _logger.LogWarning("A null exception was used to build a response with ProblemDetails. A default will be returned.");
+            return (WebErrorStatuses.InternalUnknownError.HttpCode.ToString(), WebErrorStatuses.InternalUnknownError);
         }
 
-        public (string, WebErrorStatus) BuildProblemDetailsResponse(Exception exception)
-        {
-            if (exception is null)
-            {
-                _logger.LogWarning("A null exception was used to build a response with ProblemDetails. A default will be returned.");
-                return (WebErrorStatuses.InternalUnknownError.HttpCode.ToString(), WebErrorStatuses.InternalUnknownError);
-            }
+        return GetProblemDetailsWebErrorResponse(exception);
+    }
 
-            return GetProblemDetailsWebErrorResponse(exception);
+    private (string, WebErrorStatus) GetProblemDetailsWebErrorResponse(Exception exception)
+    {
+        var traceId = Activity.Current?.Id ?? _httpContextAccessor?.HttpContext?.TraceIdentifier;
+
+        ProblemDetailsWebResponse problemDetailsResponse = new(exception, traceId);
+
+        if (TrySerializeProblemDetails(problemDetailsResponse.ProblemDetails, out var problemDetailsResponseJson))
+            return (problemDetailsResponseJson, problemDetailsResponse.WebErrorStatus);
+
+        return GetDefaultProblemDetailsWebErrorResponse(traceId);
+    }
+
+    private (string, WebErrorStatus) GetDefaultProblemDetailsWebErrorResponse(string traceId)
+    {
+        TrySerializeProblemDetails(new(traceId), out var problemDetailsDefaultResponseJson);
+
+        return (problemDetailsDefaultResponseJson, WebErrorStatuses.InternalUnknownError);
+    }
+
+    private bool TrySerializeProblemDetails(
+        ProblemDetails problemDetails,
+        out string outputJson)
+    {
+        outputJson = null;
+        Exception serializationException = null;
+
+        if (problemDetails?.TrySerializeCamelCase(out outputJson, out serializationException) is true
+            && outputJson is not null)
+        {
+            return true;
         }
 
-        private (string, WebErrorStatus) GetProblemDetailsWebErrorResponse(Exception exception)
-        {
-            var traceId = Activity.Current?.Id ?? _httpContextAccessor?.HttpContext?.TraceIdentifier;
-
-            ProblemDetailsWebResponse problemDetailsResponse = new(exception, traceId);
-
-            if (TrySerializeProblemDetails(problemDetailsResponse.ProblemDetails, out var problemDetailsResponseJson))
-                return (problemDetailsResponseJson, problemDetailsResponse.WebErrorStatus);
-
-            return GetDefaultProblemDetailsWebErrorResponse(traceId);
-        }
-
-        private (string, WebErrorStatus) GetDefaultProblemDetailsWebErrorResponse(string traceId)
-        {
-            TrySerializeProblemDetails(new(traceId), out var problemDetailsDefaultResponseJson);
-
-            return (problemDetailsDefaultResponseJson, WebErrorStatuses.InternalUnknownError);
-        }
-
-        private bool TrySerializeProblemDetails(
-            ProblemDetails problemDetails,
-            out string outputJson)
-        {
-            outputJson = null;
-            Exception serializationException = null;
-
-            if (problemDetails?.TrySerializeCamelCase(out outputJson, out serializationException) is true
-                && outputJson is not null)
-            {
-                return true;
-            }
-
-            _logger.LogError(
-                    "ProblemDetails instance was not serialized successfully. ProblemDetails: {ProblemDetails} | Serialization Exception: {SerializationException}",
-                    problemDetails,
-                    serializationException);
-            return false;
-        }
+        _logger.LogError(
+                "ProblemDetails instance was not serialized successfully. ProblemDetails: {ProblemDetails} | Serialization Exception: {SerializationException}",
+                problemDetails,
+                serializationException);
+        return false;
     }
 }

--- a/src/ToolPack.Exceptions.Web/Services/Interfaces/IProblemDetailsService.cs
+++ b/src/ToolPack.Exceptions.Web/Services/Interfaces/IProblemDetailsService.cs
@@ -1,19 +1,18 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ToolPack.Exceptions.UnitTests")]
-namespace ToolPack.Exceptions.Web.Services.Interfaces
-{
-    using System;
-    using ToolPack.Exceptions.Web.Models;
+namespace ToolPack.Exceptions.Web.Services.Interfaces;
 
-    internal interface IProblemDetailsService
-    {
-        /// <summary>
-        /// Builds a JSON formatted response with the Problem Details format (according to the RFC 7807 (https://tools.ietf.org/html/rfc7807),
-        /// as well as the error status of the response.
-        /// </summary>
-        /// <param name="exception">The exception to turn into Problem Details and matching error codes.</param>
-        /// <returns>A JSON string with the Problem Details response and its related error status codes.</returns>
-        (string, WebErrorStatus) BuildProblemDetailsResponse(Exception exception);
-    }
+using System;
+using ToolPack.Exceptions.Web.Models;
+
+internal interface IProblemDetailsService
+{
+    /// <summary>
+    /// Builds a JSON formatted response with the Problem Details format (according to the RFC 7807 (https://tools.ietf.org/html/rfc7807),
+    /// as well as the error status of the response.
+    /// </summary>
+    /// <param name="exception">The exception to turn into Problem Details and matching error codes.</param>
+    /// <returns>A JSON string with the Problem Details response and its related error status codes.</returns>
+    (string, WebErrorStatus) BuildProblemDetailsResponse(Exception exception);
 }

--- a/src/ToolPack.Exceptions.Web/ToolPack.Exceptions.Web.csproj
+++ b/src/ToolPack.Exceptions.Web/ToolPack.Exceptions.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>true</IsPackable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -14,7 +14,7 @@
             Repo: https://github.com/nunohpinheiro/toolpack-exceptions
         </Description>
 
-        <PackageVersion>1.0.0</PackageVersion>
+        <PackageVersion>2.0.0</PackageVersion>
 
         <PackageId>ToolPack.Exceptions.Web</PackageId>
         <PackageProjectUrl>https://github.com/nunohpinheiro/toolpack-exceptions</PackageProjectUrl>
@@ -32,13 +32,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="10.2.3" />
-        <PackageReference Include="Grpc.AspNetCore.Server" Version="2.38.0" />
-        <PackageReference Include="Grpc.Core.Api" Version="2.38.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-        <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
+        <PackageReference Include="Grpc.AspNetCore.Server" Version="2.46.0" />
+        <PackageReference Include="Grpc.Core.Api" Version="2.46.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0-preview.4.22229.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/UnitTests/Base/Entities/AlreadyExistsExceptionTests.cs
+++ b/tests/UnitTests/Base/Entities/AlreadyExistsExceptionTests.cs
@@ -1,71 +1,70 @@
-namespace ToolPack.Exceptions.UnitTests.Base.Entities
+namespace ToolPack.Exceptions.UnitTests.Base.Entities;
+
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using ToolPack.Exceptions.Base.Entities;
+
+public class AlreadyExistsExceptionTests
 {
-    using FluentAssertions;
-    using NUnit.Framework;
-    using System;
-    using ToolPack.Exceptions.Base.Entities;
+    private const string _expectedMessageDefault = AlreadyExistsException.MessageDefault;
 
-    public class AlreadyExistsExceptionTests
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public void Ctor_EmptyMessage_ReturnsExceptionWithDefaultMessage(string message)
     {
-        private const string _expectedMessageDefault = AlreadyExistsException.MessageDefault;
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public void Ctor_EmptyMessage_ReturnsExceptionWithDefaultMessage(string message)
-        {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new AlreadyExistsException(message, innerException);
 
-            // Act
-            var actual = new AlreadyExistsException(message, innerException);
+        // Assert
+        actual.Should().Match<AlreadyExistsException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+    }
 
-            // Assert
-            actual.Should().Match<AlreadyExistsException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-        }
+    [Test]
+    public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
+    {
+        // Act
+        var actual = new AlreadyExistsException();
 
-        [Test]
-        public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
-        {
-            // Act
-            var actual = new AlreadyExistsException();
+        // Assert
+        actual.Should().Match<AlreadyExistsException>(x => x.Message.Equals(_expectedMessageDefault));
+    }
 
-            // Assert
-            actual.Should().Match<AlreadyExistsException>(x => x.Message.Equals(_expectedMessageDefault));
-        }
+    [Test]
+    public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
+    {
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
-        {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new AlreadyExistsException(innerException);
 
-            // Act
-            var actual = new AlreadyExistsException(innerException);
+        // Assert
+        actual.Should().Match<AlreadyExistsException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+    }
 
-            // Assert
-            actual.Should().Match<AlreadyExistsException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-        }
+    [Test]
+    public void Ctor_WithMessageAndInnerException_ReturnsExceptionWithMessageAndInnerException()
+    {
+        // Arrange
+        var message = "just a sample message";
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        public void Ctor_WithMessageAndInnerException_ReturnsExceptionWithMessageAndInnerException()
-        {
-            // Arrange
-            var message = "just a sample message";
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new AlreadyExistsException(message, innerException);
 
-            // Act
-            var actual = new AlreadyExistsException(message, innerException);
-
-            // Assert
-            actual.Should().Match<AlreadyExistsException>(x =>
-                                x.Message.Equals(message)
-                                && x.InnerException.Equals(innerException));
-        }
+        // Assert
+        actual.Should().Match<AlreadyExistsException>(x =>
+                            x.Message.Equals(message)
+                            && x.InnerException.Equals(innerException));
     }
 }

--- a/tests/UnitTests/Base/Entities/CustomBaseExceptionTests.cs
+++ b/tests/UnitTests/Base/Entities/CustomBaseExceptionTests.cs
@@ -1,71 +1,70 @@
-namespace ToolPack.Exceptions.UnitTests.Base.Entities
+namespace ToolPack.Exceptions.UnitTests.Base.Entities;
+
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using ToolPack.Exceptions.Base.Entities;
+
+public class CustomBaseExceptionTests
 {
-    using FluentAssertions;
-    using NUnit.Framework;
-    using System;
-    using ToolPack.Exceptions.Base.Entities;
+    private const string _expectedMessageDefault = CustomBaseException.MessageDefault;
 
-    public class CustomBaseExceptionTests
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public void Ctor_EmptyMessage_ReturnsExceptionWithDefaultMessage(string message)
     {
-        private const string _expectedMessageDefault = CustomBaseException.MessageDefault;
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public void Ctor_EmptyMessage_ReturnsExceptionWithDefaultMessage(string message)
-        {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new CustomBaseException(message, innerException);
 
-            // Act
-            var actual = new CustomBaseException(message, innerException);
+        // Assert
+        actual.Should().Match<CustomBaseException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+    }
 
-            // Assert
-            actual.Should().Match<CustomBaseException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-        }
+    [Test]
+    public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
+    {
+        // Act
+        var actual = new CustomBaseException();
 
-        [Test]
-        public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
-        {
-            // Act
-            var actual = new CustomBaseException();
+        // Assert
+        actual.Should().Match<CustomBaseException>(x => x.Message.Equals(_expectedMessageDefault));
+    }
 
-            // Assert
-            actual.Should().Match<CustomBaseException>(x => x.Message.Equals(_expectedMessageDefault));
-        }
+    [Test]
+    public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
+    {
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
-        {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new CustomBaseException(innerException);
 
-            // Act
-            var actual = new CustomBaseException(innerException);
+        // Assert
+        actual.Should().Match<CustomBaseException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+    }
 
-            // Assert
-            actual.Should().Match<CustomBaseException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-        }
+    [Test]
+    public void Ctor_WithMessageAndInnerException_ReturnsExceptionWithMessageAndInnerException()
+    {
+        // Arrange
+        var message = "just a sample message";
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        public void Ctor_WithMessageAndInnerException_ReturnsExceptionWithMessageAndInnerException()
-        {
-            // Arrange
-            var message = "just a sample message";
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new CustomBaseException(message, innerException);
 
-            // Act
-            var actual = new CustomBaseException(message, innerException);
-
-            // Assert
-            actual.Should().Match<CustomBaseException>(x =>
-                                x.Message.Equals(message)
-                                && x.InnerException.Equals(innerException));
-        }
+        // Assert
+        actual.Should().Match<CustomBaseException>(x =>
+                            x.Message.Equals(message)
+                            && x.InnerException.Equals(innerException));
     }
 }

--- a/tests/UnitTests/Base/Entities/ExternalComponentExceptionTests.cs
+++ b/tests/UnitTests/Base/Entities/ExternalComponentExceptionTests.cs
@@ -1,88 +1,87 @@
-namespace ToolPack.Exceptions.UnitTests.Base.Entities
+namespace ToolPack.Exceptions.UnitTests.Base.Entities;
+
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using ToolPack.Exceptions.Base.Entities;
+
+public class ExternalComponentExceptionTests
 {
-    using FluentAssertions;
-    using NUnit.Framework;
-    using System;
-    using ToolPack.Exceptions.Base.Entities;
+    private const string _expectedMessageDefault = ExternalComponentException.MessageDefault;
 
-    public class ExternalComponentExceptionTests
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public void Ctor_EmptyMessage_ReturnsExceptionWithDefaultMessage(string message)
     {
-        private const string _expectedMessageDefault = ExternalComponentException.MessageDefault;
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public void Ctor_EmptyMessage_ReturnsExceptionWithDefaultMessage(string message)
-        {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new ExternalComponentException(message, innerException);
 
-            // Act
-            var actual = new ExternalComponentException(message, innerException);
+        // Assert
+        actual.Should().Match<ExternalComponentException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+    }
 
-            // Assert
-            actual.Should().Match<ExternalComponentException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-        }
+    [Test]
+    public void Ctor_WithComponent_ReturnsExceptionWithMatchingMessage()
+    {
+        // Arrange
+        var componentName = "sample name";
+        var componentDescription = "sample key";
+        var expectedMessage = _expectedMessageDefault + $" | Component name: '{componentName}'. Component description: '{componentDescription}'.";
 
-        [Test]
-        public void Ctor_WithComponent_ReturnsExceptionWithMatchingMessage()
-        {
-            // Arrange
-            var componentName = "sample name";
-            var componentDescription = "sample key";
-            var expectedMessage = _expectedMessageDefault + $" | Component name: '{componentName}'. Component description: '{componentDescription}'.";
+        // Act
+        var actual = new ExternalComponentException(componentName, componentDescription);
 
-            // Act
-            var actual = new ExternalComponentException(componentName, componentDescription);
+        // Assert
+        actual.Should().Match<ExternalComponentException>(x =>
+                            x.Message.Equals(expectedMessage)
+                            && x.InnerException == null);
+    }
 
-            // Assert
-            actual.Should().Match<ExternalComponentException>(x =>
-                                x.Message.Equals(expectedMessage)
-                                && x.InnerException == null);
-        }
+    [Test]
+    public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
+    {
+        // Act
+        var actual = new ExternalComponentException();
 
-        [Test]
-        public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
-        {
-            // Act
-            var actual = new ExternalComponentException();
+        // Assert
+        actual.Should().Match<ExternalComponentException>(x => x.Message.Equals(_expectedMessageDefault));
+    }
 
-            // Assert
-            actual.Should().Match<ExternalComponentException>(x => x.Message.Equals(_expectedMessageDefault));
-        }
+    [Test]
+    public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
+    {
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
-        {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new ExternalComponentException(innerException);
 
-            // Act
-            var actual = new ExternalComponentException(innerException);
+        // Assert
+        actual.Should().Match<ExternalComponentException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+    }
 
-            // Assert
-            actual.Should().Match<ExternalComponentException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-        }
+    [Test]
+    public void Ctor_WithMessageAndInnerException_ReturnsExceptionWithMessageAndInnerException()
+    {
+        // Arrange
+        var message = "just a sample message";
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        public void Ctor_WithMessageAndInnerException_ReturnsExceptionWithMessageAndInnerException()
-        {
-            // Arrange
-            var message = "just a sample message";
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new ExternalComponentException(message, innerException);
 
-            // Act
-            var actual = new ExternalComponentException(message, innerException);
-
-            // Assert
-            actual.Should().Match<ExternalComponentException>(x =>
-                                x.Message.Equals(message)
-                                && x.InnerException.Equals(innerException));
-        }
+        // Assert
+        actual.Should().Match<ExternalComponentException>(x =>
+                            x.Message.Equals(message)
+                            && x.InnerException.Equals(innerException));
     }
 }

--- a/tests/UnitTests/Base/Entities/NotFoundExceptionTests.cs
+++ b/tests/UnitTests/Base/Entities/NotFoundExceptionTests.cs
@@ -1,88 +1,87 @@
-namespace ToolPack.Exceptions.UnitTests.Base.Entities
+namespace ToolPack.Exceptions.UnitTests.Base.Entities;
+
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using ToolPack.Exceptions.Base.Entities;
+
+public class NotFoundExceptionTests
 {
-    using FluentAssertions;
-    using NUnit.Framework;
-    using System;
-    using ToolPack.Exceptions.Base.Entities;
+    private const string _expectedMessageDefault = NotFoundException.MessageDefault;
 
-    public class NotFoundExceptionTests
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public void Ctor_EmptyMessage_ReturnsExceptionWithDefaultMessage(string message)
     {
-        private const string _expectedMessageDefault = NotFoundException.MessageDefault;
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public void Ctor_EmptyMessage_ReturnsExceptionWithDefaultMessage(string message)
-        {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new NotFoundException(message, innerException);
 
-            // Act
-            var actual = new NotFoundException(message, innerException);
+        // Assert
+        actual.Should().Match<NotFoundException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+    }
 
-            // Assert
-            actual.Should().Match<NotFoundException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-        }
+    [Test]
+    public void Ctor_WithEntity_ReturnsExceptionWithMatchingMessage()
+    {
+        // Arrange
+        var entityName = "sample name";
+        var entityKey = "sample key";
+        var expectedMessage = _expectedMessageDefault + $" | Entity: '{entityName}'. Entity key: '{entityKey}'.";
 
-        [Test]
-        public void Ctor_WithEntity_ReturnsExceptionWithMatchingMessage()
-        {
-            // Arrange
-            var entityName = "sample name";
-            var entityKey = "sample key";
-            var expectedMessage = _expectedMessageDefault + $" | Entity: '{entityName}'. Entity key: '{entityKey}'.";
+        // Act
+        var actual = new NotFoundException(entityName, entityKey);
 
-            // Act
-            var actual = new NotFoundException(entityName, entityKey);
+        // Assert
+        actual.Should().Match<NotFoundException>(x =>
+                            x.Message.Equals(expectedMessage)
+                            && x.InnerException == null);
+    }
 
-            // Assert
-            actual.Should().Match<NotFoundException>(x =>
-                                x.Message.Equals(expectedMessage)
-                                && x.InnerException == null);
-        }
+    [Test]
+    public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
+    {
+        // Act
+        var actual = new NotFoundException();
 
-        [Test]
-        public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
-        {
-            // Act
-            var actual = new NotFoundException();
+        // Assert
+        actual.Should().Match<NotFoundException>(x => x.Message.Equals(_expectedMessageDefault));
+    }
 
-            // Assert
-            actual.Should().Match<NotFoundException>(x => x.Message.Equals(_expectedMessageDefault));
-        }
+    [Test]
+    public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
+    {
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
-        {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new NotFoundException(innerException);
 
-            // Act
-            var actual = new NotFoundException(innerException);
+        // Assert
+        actual.Should().Match<NotFoundException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+    }
 
-            // Assert
-            actual.Should().Match<NotFoundException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-        }
+    [Test]
+    public void Ctor_WithMessageAndInnerException_ReturnsExceptionWithMessageAndInnerException()
+    {
+        // Arrange
+        var message = "just a sample message";
+        var innerException = new Exception("just a sample inner exception");
 
-        [Test]
-        public void Ctor_WithMessageAndInnerException_ReturnsExceptionWithMessageAndInnerException()
-        {
-            // Arrange
-            var message = "just a sample message";
-            var innerException = new Exception("just a sample inner exception");
+        // Act
+        var actual = new NotFoundException(message, innerException);
 
-            // Act
-            var actual = new NotFoundException(message, innerException);
-
-            // Assert
-            actual.Should().Match<NotFoundException>(x =>
-                                x.Message.Equals(message)
-                                && x.InnerException.Equals(innerException));
-        }
+        // Assert
+        actual.Should().Match<NotFoundException>(x =>
+                            x.Message.Equals(message)
+                            && x.InnerException.Equals(innerException));
     }
 }

--- a/tests/UnitTests/Base/Entities/ValidationFailedExceptionTests.cs
+++ b/tests/UnitTests/Base/Entities/ValidationFailedExceptionTests.cs
@@ -1,90 +1,89 @@
-namespace ToolPack.Exceptions.UnitTests.Base.Entities
+namespace ToolPack.Exceptions.UnitTests.Base.Entities;
+
+using FluentAssertions;
+using FluentValidation.Results;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ToolPack.Exceptions.Base.Entities;
+
+public class ValidationFailedExceptionTests
 {
-    using FluentAssertions;
-    using FluentValidation.Results;
-    using NUnit.Framework;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using ToolPack.Exceptions.Base.Entities;
+    private const string _expectedMessageDefault = ValidationFailedException.MessageDefault;
+    private static IDictionary<string, string[]> ExpectedDefaultErrors { get; } = new Dictionary<string, string[]>();
 
-    public class ValidationFailedExceptionTests
+    [Test]
+    public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
     {
-        private const string _expectedMessageDefault = ValidationFailedException.MessageDefault;
-        private static IDictionary<string, string[]> ExpectedDefaultErrors { get; } = new Dictionary<string, string[]>();
+        // Act
+        var actual = new ValidationFailedException();
 
-        [Test]
-        public void Ctor_NoParameter_ReturnsExceptionWithDefaults()
+        // Assert
+        actual.Should().Match<ValidationFailedException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException == null);
+        actual.Errors.Should().BeEquivalentTo(ExpectedDefaultErrors);
+    }
+
+    [Test]
+    public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
+    {
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
+
+        // Act
+        var actual = new ValidationFailedException(innerException);
+
+        // Assert
+        actual.Should().Match<ValidationFailedException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+        actual.Errors.Should().BeEquivalentTo(ExpectedDefaultErrors);
+    }
+
+    [Test]
+    public void Ctor_WithInnerExceptionAndEmptyValidationFailures_MatchesGivenParametersAndDefaultMessage()
+    {
+        // Arrange
+        IEnumerable<ValidationFailure> failures = Enumerable.Empty<ValidationFailure>();
+        var innerException = new Exception("just a sample inner exception");
+
+        // Act
+        var actual = new ValidationFailedException(failures, innerException);
+
+        // Assert
+        actual.Should().Match<ValidationFailedException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+        actual.Errors.Should().BeEquivalentTo(ExpectedDefaultErrors);
+    }
+
+    [Test]
+    public void Ctor_WithInnerExceptionAndValidationFailures_MatchesGivenParametersAndDefaultMessage()
+    {
+        // Arrange
+        var innerException = new Exception("just a sample inner exception");
+
+        List<ValidationFailure> failures = new()
         {
-            // Act
-            var actual = new ValidationFailedException();
-
-            // Assert
-            actual.Should().Match<ValidationFailedException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException == null);
-            actual.Errors.Should().BeEquivalentTo(ExpectedDefaultErrors);
-        }
-
-        [Test]
-        public void Ctor_WithInnerException_ReturnsExceptionWithDefaultsAndInnerException()
+            new("prop1", "msg11"),
+            new("prop1", "msg12"),
+            new("prop2", "msg21")
+        };
+        Dictionary<string, string[]> expectedErrors = new()
         {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
+            { "prop1", new string[] { "msg11", "msg12" } },
+            { "prop2", new string[] { "msg21" } }
+        };
 
-            // Act
-            var actual = new ValidationFailedException(innerException);
+        // Act
+        var actual = new ValidationFailedException(failures, innerException);
 
-            // Assert
-            actual.Should().Match<ValidationFailedException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-            actual.Errors.Should().BeEquivalentTo(ExpectedDefaultErrors);
-        }
-
-        [Test]
-        public void Ctor_WithInnerExceptionAndEmptyValidationFailures_MatchesGivenParametersAndDefaultMessage()
-        {
-            // Arrange
-            IEnumerable<ValidationFailure> failures = Enumerable.Empty<ValidationFailure>();
-            var innerException = new Exception("just a sample inner exception");
-
-            // Act
-            var actual = new ValidationFailedException(failures, innerException);
-
-            // Assert
-            actual.Should().Match<ValidationFailedException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-            actual.Errors.Should().BeEquivalentTo(ExpectedDefaultErrors);
-        }
-
-        [Test]
-        public void Ctor_WithInnerExceptionAndValidationFailures_MatchesGivenParametersAndDefaultMessage()
-        {
-            // Arrange
-            var innerException = new Exception("just a sample inner exception");
-
-            List<ValidationFailure> failures = new()
-            {
-                new("prop1", "msg11"),
-                new("prop1", "msg12"),
-                new("prop2", "msg21")
-            };
-            Dictionary<string, string[]> expectedErrors = new()
-            {
-                { "prop1", new string[] { "msg11", "msg12" } },
-                { "prop2", new string[] { "msg21" } }
-            };
-
-            // Act
-            var actual = new ValidationFailedException(failures, innerException);
-
-            // Assert
-            actual.Should().Match<ValidationFailedException>(x =>
-                                x.Message.Equals(_expectedMessageDefault)
-                                && x.InnerException.Equals(innerException));
-            actual.Errors.Should().BeEquivalentTo(expectedErrors);
-        }
+        // Assert
+        actual.Should().Match<ValidationFailedException>(x =>
+                            x.Message.Equals(_expectedMessageDefault)
+                            && x.InnerException.Equals(innerException));
+        actual.Errors.Should().BeEquivalentTo(expectedErrors);
     }
 }

--- a/tests/UnitTests/Base/Guard/ThrowWhenTests.cs
+++ b/tests/UnitTests/Base/Guard/ThrowWhenTests.cs
@@ -1,328 +1,327 @@
-namespace ToolPack.Exceptions.UnitTests.Base.Guard
+namespace ToolPack.Exceptions.UnitTests.Base.Guard;
+
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using ToolPack.Exceptions.Base.Entities;
+using ToolPack.Exceptions.Base.Guard;
+
+public class ThrowWhenTests
 {
-    using FluentAssertions;
-    using NUnit.Framework;
-    using System;
-    using ToolPack.Exceptions.Base.Entities;
-    using ToolPack.Exceptions.Base.Guard;
+    private const string StringNullOrWhiteSpaceMsg = "String cannot be null, empty or white space. Argument description: ";
 
-    public class ThrowWhenTests
+    [Test]
+    public void ArgumentNull_EmptyParams_NotThrowsException()
     {
-        private const string StringNullOrWhiteSpaceMsg = "String cannot be null, empty or white space. Argument description: ";
+        // Act
+        Action act = () => ThrowWhen.ArgumentNull();
 
-        [Test]
-        public void ArgumentNull_EmptyParams_NotThrowsException()
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ArgumentNull_Params_ConditionsVerify_NotThrowsException()
+    {
+        // Arrange
+        int? argument1 = 3;
+        int? argument2 = 4;
+
+        var paramsArray = new (object, string)[]
         {
-            // Act
-            Action act = () => ThrowWhen.ArgumentNull();
+            (argument1, nameof(argument1)),
+            (argument2, nameof(argument2))
+        };
 
-            // Assert
-            act.Should().NotThrow();
-        }
+        // Act
+        Action act = () => ThrowWhen.ArgumentNull(paramsArray);
 
-        [Test]
-        public void ArgumentNull_Params_ConditionsVerify_NotThrowsException()
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ArgumentNull_Params_FirstConditionNotVerifies_ThrowsArgumentNullException()
+    {
+        // Arrange
+        int? argument1 = null;
+        int? argument2 = 3;
+
+        var paramsArray = new (object, string)[]
         {
-            // Arrange
-            int? argument1 = 3;
-            int? argument2 = 4;
+            (argument1, nameof(argument1)),
+            (argument2, nameof(argument2))
+        };
 
-            var paramsArray = new (object, string)[]
-            {
-                (argument1, nameof(argument1)),
-                (argument2, nameof(argument2))
-            };
+        // Act
+        Action act = () => ThrowWhen.ArgumentNull(paramsArray);
 
-            // Act
-            Action act = () => ThrowWhen.ArgumentNull(paramsArray);
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+                    .Which.ParamName.Should().Be(nameof(argument1));
+    }
 
-            // Assert
-            act.Should().NotThrow();
-        }
+    [Test]
+    public void ArgumentNull_Params_SecondConditionNotVerifies_ThrowsArgumentNullException()
+    {
+        // Arrange
+        int? argument1 = 3;
+        int? argument2 = null;
 
-        [Test]
-        public void ArgumentNull_Params_FirstConditionNotVerifies_ThrowsArgumentNullException()
+        var paramsArray = new (object, string)[]
         {
-            // Arrange
-            int? argument1 = null;
-            int? argument2 = 3;
+            (argument1, nameof(argument1)),
+            (argument2, nameof(argument2))
+        };
 
-            var paramsArray = new (object, string)[]
-            {
-                (argument1, nameof(argument1)),
-                (argument2, nameof(argument2))
-            };
+        // Act
+        Action act = () => ThrowWhen.ArgumentNull(paramsArray);
 
-            // Act
-            Action act = () => ThrowWhen.ArgumentNull(paramsArray);
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+                    .Which.ParamName.Should().Be(nameof(argument2));
+    }
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                        .Which.ParamName.Should().Be(nameof(argument1));
-        }
+    [Test]
+    public void ArgumentNullT_ConditionNotVerifies_ThrowsArgumentNullException()
+    {
+        // Arrange
+        int? argument = null;
+        string argumentDescription = nameof(argument);
 
-        [Test]
-        public void ArgumentNull_Params_SecondConditionNotVerifies_ThrowsArgumentNullException()
+        // Act
+        Action act = () => ThrowWhen.ArgumentNull(argument, argumentDescription);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+                    .Which.ParamName.Should().Be(argumentDescription);
+    }
+
+    [Test]
+    public void ArgumentNullT_ConditionVerifies_NotThrowsException()
+    {
+        // Arrange
+        int? argument = 3;
+        string argumentDescription = nameof(argument);
+
+        // Act
+        Action act = () => ThrowWhen.ArgumentNull(argument, argumentDescription);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ArgumentNullThrowNotFound_ConditionNotVerifies_ThrowsNotFoundException()
+    {
+        // Arrange
+        int? argument = null;
+        string argumentDescription = nameof(argument);
+        string argumentKey = "argument key";
+
+        NotFoundException expectedException = new(argumentDescription, argumentKey);
+
+        // Act
+        Action act = () => ThrowWhen.ArgumentNullThrowNotFound(argument, argumentDescription, argumentKey);
+
+        // Assert
+        act.Should().Throw<NotFoundException>()
+                    .WithMessage(expectedException.Message);
+    }
+
+    [Test]
+    public void ArgumentNullThrowNotFound_ConditionVerifies_NotThrowsException()
+    {
+        // Arrange
+        int? argument = 3;
+        string argumentDescription = nameof(argument);
+
+        // Act
+        Action act = () => ThrowWhen.ArgumentNullThrowNotFound(argument, argumentDescription, "argument key");
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ArgumentOutOfRange_ConditionNotVerifies_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        bool condition = false;
+        string argumentDescription = "sample description";
+
+        ArgumentOutOfRangeException expectedException = new(argumentDescription);
+
+        // Act
+        Action act = () => ThrowWhen.ArgumentOutOfRange(condition, argumentDescription);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+                    .WithMessage(expectedException.Message);
+    }
+
+    [Test]
+    public void ArgumentOutOfRange_ConditionVerifies_NotThrowsException()
+    {
+        // Arrange
+        bool condition = true;
+        string argumentDescription = "sample description";
+
+        // Act
+        Action act = () => ThrowWhen.ArgumentOutOfRange(condition, argumentDescription);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+
+
+
+
+
+
+    [Test]
+    public void ArgumentStringNullOrWhiteSpace_EmptyParams_NotThrowsException()
+    {
+        // Act
+        Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ArgumentStringNullOrWhiteSpace_Params_ConditionsVerify_NotThrowsException()
+    {
+        // Arrange
+        string argument1 = "such a valid string";
+        string argument2 = "such a valid string";
+
+        var paramsArray = new (string, string)[]
         {
-            // Arrange
-            int? argument1 = 3;
-            int? argument2 = null;
+            (argument1, nameof(argument1)),
+            (argument2, nameof(argument2))
+        };
 
-            var paramsArray = new (object, string)[]
-            {
-                (argument1, nameof(argument1)),
-                (argument2, nameof(argument2))
-            };
+        // Act
+        Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(paramsArray);
 
-            // Act
-            Action act = () => ThrowWhen.ArgumentNull(paramsArray);
+        // Assert
+        act.Should().NotThrow();
+    }
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                        .Which.ParamName.Should().Be(nameof(argument2));
-        }
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public void ArgumentStringNullOrWhiteSpace_Params_FirstConditionNotVerifies_ThrowsArgumentException(string invalidString)
+    {
+        // Arrange
+        string argument1 = invalidString;
+        string argument2 = "such a valid string";
 
-        [Test]
-        public void ArgumentNullT_ConditionNotVerifies_ThrowsArgumentNullException()
+        var paramsArray = new (string, string)[]
         {
-            // Arrange
-            int? argument = null;
-            string argumentDescription = nameof(argument);
+            (argument1, nameof(argument1)),
+            (argument2, nameof(argument2))
+        };
 
-            // Act
-            Action act = () => ThrowWhen.ArgumentNull(argument, argumentDescription);
+        var expectedMessage = $"{StringNullOrWhiteSpaceMsg}{nameof(argument1)}";
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                        .Which.ParamName.Should().Be(argumentDescription);
-        }
+        // Act
+        Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(paramsArray);
 
-        [Test]
-        public void ArgumentNullT_ConditionVerifies_NotThrowsException()
+        // Assert
+        act.Should().Throw<ArgumentException>()
+                    .WithMessage(expectedMessage);
+    }
+
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public void ArgumentStringNullOrWhiteSpace_Params_SecondConditionNotVerifies_ThrowsArgumentException(string invalidString)
+    {
+        // Arrange
+        string argument1 = "such a valid string";
+        string argument2 = invalidString;
+
+        var paramsArray = new (string, string)[]
         {
-            // Arrange
-            int? argument = 3;
-            string argumentDescription = nameof(argument);
+            (argument1, nameof(argument1)),
+            (argument2, nameof(argument2))
+        };
 
-            // Act
-            Action act = () => ThrowWhen.ArgumentNull(argument, argumentDescription);
+        var expectedMessage = $"{StringNullOrWhiteSpaceMsg}{nameof(argument2)}";
 
-            // Assert
-            act.Should().NotThrow();
-        }
+        // Act
+        Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(paramsArray);
 
-        [Test]
-        public void ArgumentNullThrowNotFound_ConditionNotVerifies_ThrowsNotFoundException()
-        {
-            // Arrange
-            int? argument = null;
-            string argumentDescription = nameof(argument);
-            string argumentKey = "argument key";
+        // Assert
+        act.Should().Throw<ArgumentException>()
+                    .WithMessage(expectedMessage);
+    }
 
-            NotFoundException expectedException = new(argumentDescription, argumentKey);
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public void ArgumentStringNullOrWhiteSpace_ConditionNotVerifies_ThrowsArgumentException(string invalidString)
+    {
+        // Arrange
+        string argument = invalidString;
+        string argumentDescription = nameof(argument);
 
-            // Act
-            Action act = () => ThrowWhen.ArgumentNullThrowNotFound(argument, argumentDescription, argumentKey);
+        var expectedMessage = $"{StringNullOrWhiteSpaceMsg}{argumentDescription}";
 
-            // Assert
-            act.Should().Throw<NotFoundException>()
-                        .WithMessage(expectedException.Message);
-        }
+        // Act
+        Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(argument, argumentDescription);
 
-        [Test]
-        public void ArgumentNullThrowNotFound_ConditionVerifies_NotThrowsException()
-        {
-            // Arrange
-            int? argument = 3;
-            string argumentDescription = nameof(argument);
+        // Assert
+        act.Should().Throw<ArgumentException>()
+                    .WithMessage(expectedMessage);
+    }
 
-            // Act
-            Action act = () => ThrowWhen.ArgumentNullThrowNotFound(argument, argumentDescription, "argument key");
+    [Test]
+    public void ArgumentStringNullOrWhiteSpace_ConditionVerifies_NotThrowsException()
+    {
+        // Arrange
+        string argument = "such a valid string";
+        string argumentDescription = nameof(argument);
 
-            // Assert
-            act.Should().NotThrow();
-        }
+        // Act
+        Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(argument, argumentDescription);
 
-        [Test]
-        public void ArgumentOutOfRange_ConditionNotVerifies_ThrowsArgumentOutOfRangeException()
-        {
-            // Arrange
-            bool condition = false;
-            string argumentDescription = "sample description";
+        // Assert
+        act.Should().NotThrow();
+    }
 
-            ArgumentOutOfRangeException expectedException = new(argumentDescription);
+    [Test]
+    public void ConditionFails_ConditionNotVerifies_ThrowsException()
+    {
+        // Arrange
+        var condition = false;
+        var exception = new Exception("sample exception");
 
-            // Act
-            Action act = () => ThrowWhen.ArgumentOutOfRange(condition, argumentDescription);
+        // Act
+        Action act = () => ThrowWhen.ConditionFails(condition, exception);
 
-            // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                        .WithMessage(expectedException.Message);
-        }
+        // Assert
+        act.Should().Throw<Exception>()
+                    .WithMessage(exception.Message);
+    }
 
-        [Test]
-        public void ArgumentOutOfRange_ConditionVerifies_NotThrowsException()
-        {
-            // Arrange
-            bool condition = true;
-            string argumentDescription = "sample description";
+    [Test]
+    public void ConditionFails_ConditionVerifies_NotThrowsException()
+    {
+        // Arrange
+        var condition = true;
+        var exception = new Exception("sample exception");
 
-            // Act
-            Action act = () => ThrowWhen.ArgumentOutOfRange(condition, argumentDescription);
+        // Act
+        Action act = () => ThrowWhen.ConditionFails(condition, exception);
 
-            // Assert
-            act.Should().NotThrow();
-        }
-
-
-
-
-
-
-
-        [Test]
-        public void ArgumentStringNullOrWhiteSpace_EmptyParams_NotThrowsException()
-        {
-            // Act
-            Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace();
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Test]
-        public void ArgumentStringNullOrWhiteSpace_Params_ConditionsVerify_NotThrowsException()
-        {
-            // Arrange
-            string argument1 = "such a valid string";
-            string argument2 = "such a valid string";
-
-            var paramsArray = new (string, string)[]
-            {
-                (argument1, nameof(argument1)),
-                (argument2, nameof(argument2))
-            };
-
-            // Act
-            Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(paramsArray);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public void ArgumentStringNullOrWhiteSpace_Params_FirstConditionNotVerifies_ThrowsArgumentException(string invalidString)
-        {
-            // Arrange
-            string argument1 = invalidString;
-            string argument2 = "such a valid string";
-
-            var paramsArray = new (string, string)[]
-            {
-                (argument1, nameof(argument1)),
-                (argument2, nameof(argument2))
-            };
-
-            var expectedMessage = $"{StringNullOrWhiteSpaceMsg}{nameof(argument1)}";
-
-            // Act
-            Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(paramsArray);
-
-            // Assert
-            act.Should().Throw<ArgumentException>()
-                        .WithMessage(expectedMessage);
-        }
-
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public void ArgumentStringNullOrWhiteSpace_Params_SecondConditionNotVerifies_ThrowsArgumentException(string invalidString)
-        {
-            // Arrange
-            string argument1 = "such a valid string";
-            string argument2 = invalidString;
-
-            var paramsArray = new (string, string)[]
-            {
-                (argument1, nameof(argument1)),
-                (argument2, nameof(argument2))
-            };
-
-            var expectedMessage = $"{StringNullOrWhiteSpaceMsg}{nameof(argument2)}";
-
-            // Act
-            Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(paramsArray);
-
-            // Assert
-            act.Should().Throw<ArgumentException>()
-                        .WithMessage(expectedMessage);
-        }
-
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public void ArgumentStringNullOrWhiteSpace_ConditionNotVerifies_ThrowsArgumentException(string invalidString)
-        {
-            // Arrange
-            string argument = invalidString;
-            string argumentDescription = nameof(argument);
-
-            var expectedMessage = $"{StringNullOrWhiteSpaceMsg}{argumentDescription}";
-
-            // Act
-            Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(argument, argumentDescription);
-
-            // Assert
-            act.Should().Throw<ArgumentException>()
-                        .WithMessage(expectedMessage);
-        }
-
-        [Test]
-        public void ArgumentStringNullOrWhiteSpace_ConditionVerifies_NotThrowsException()
-        {
-            // Arrange
-            string argument = "such a valid string";
-            string argumentDescription = nameof(argument);
-
-            // Act
-            Action act = () => ThrowWhen.ArgumentStringNullOrWhiteSpace(argument, argumentDescription);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Test]
-        public void ConditionFails_ConditionNotVerifies_ThrowsException()
-        {
-            // Arrange
-            var condition = false;
-            var exception = new Exception("sample exception");
-
-            // Act
-            Action act = () => ThrowWhen.ConditionFails(condition, exception);
-
-            // Assert
-            act.Should().Throw<Exception>()
-                        .WithMessage(exception.Message);
-        }
-
-        [Test]
-        public void ConditionFails_ConditionVerifies_NotThrowsException()
-        {
-            // Arrange
-            var condition = true;
-            var exception = new Exception("sample exception");
-
-            // Act
-            Action act = () => ThrowWhen.ConditionFails(condition, exception);
-
-            // Assert
-            act.Should().NotThrow();
-        }
+        // Assert
+        act.Should().NotThrow();
     }
 }

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0-preview-20220426-02" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UnitTests/Web/Extensions/DependencyInjectionExtensionsTests.cs
+++ b/tests/UnitTests/Web/Extensions/DependencyInjectionExtensionsTests.cs
@@ -1,43 +1,42 @@
-namespace ToolPack.Exceptions.UnitTests.Web.Extensions
+namespace ToolPack.Exceptions.UnitTests.Web.Extensions;
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using ToolPack.Exceptions.Web.Extensions;
+using ToolPack.Exceptions.Web.Services.Interfaces;
+
+public class DependencyInjectionExtensionsTests
 {
-    using FluentAssertions;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.DependencyInjection;
-    using NUnit.Framework;
-    using ToolPack.Exceptions.Web.Extensions;
-    using ToolPack.Exceptions.Web.Services.Interfaces;
+    private static IServiceCollection _servicesFixture => new ServiceCollection().AddLogging();
 
-    public class DependencyInjectionExtensionsTests
+    [Test]
+    public void AddToolPackExceptions_ExpectedServicesAreAdded()
     {
-        private static IServiceCollection _servicesFixture => new ServiceCollection().AddLogging();
+        // Act
+        var servicesResult = _servicesFixture.AddToolPackExceptions();
 
-        [Test]
-        public void AddToolPackExceptions_ExpectedServicesAreAdded()
-        {
-            // Act
-            var servicesResult = _servicesFixture.AddToolPackExceptions();
+        // Assert
+        AssertExceptionServices(servicesResult);
+    }
 
-            // Assert
-            AssertExceptionServices(servicesResult);
-        }
+    [Test]
+    public void AddToolPackExceptionsGrpc_ExpectedServicesAreAdded()
+    {
+        // Act
+        var servicesResult = _servicesFixture.AddToolPackExceptionsGrpc();
 
-        [Test]
-        public void AddToolPackExceptionsGrpc_ExpectedServicesAreAdded()
-        {
-            // Act
-            var servicesResult = _servicesFixture.AddToolPackExceptionsGrpc();
+        // Assert
+        AssertExceptionServices(servicesResult);
+    }
 
-            // Assert
-            AssertExceptionServices(servicesResult);
-        }
+    private static void AssertExceptionServices(IServiceCollection services)
+    {
+        var problemDetailsSvc = services.BuildServiceProvider().GetService<IProblemDetailsService>();
+        var httpContextSvc = services.BuildServiceProvider().GetService<IHttpContextAccessor>();
 
-        private static void AssertExceptionServices(IServiceCollection services)
-        {
-            var problemDetailsSvc = services.BuildServiceProvider().GetService<IProblemDetailsService>();
-            var httpContextSvc = services.BuildServiceProvider().GetService<IHttpContextAccessor>();
-
-            problemDetailsSvc.Should().NotBeNull();
-            httpContextSvc.Should().NotBeNull();
-        }
+        problemDetailsSvc.Should().NotBeNull();
+        httpContextSvc.Should().NotBeNull();
     }
 }

--- a/tests/UnitTests/Web/Extensions/JsonExtensionsTests.cs
+++ b/tests/UnitTests/Web/Extensions/JsonExtensionsTests.cs
@@ -1,32 +1,31 @@
-namespace ToolPack.Exceptions.UnitTests.Web.Extensions
+namespace ToolPack.Exceptions.UnitTests.Web.Extensions;
+
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using ToolPack.Exceptions.Web.Extensions;
+
+public class JsonExtensionsTests
 {
-    using FluentAssertions;
-    using NUnit.Framework;
-    using System;
-    using ToolPack.Exceptions.Web.Extensions;
-
-    public class JsonExtensionsTests
+    [Test]
+    public void TrySerializeCamelCase_InputSerializable_ReturnsTrue_OutputStringMatches_OutputExceptionIsNotNull()
     {
-        [Test]
-        public void TrySerializeCamelCase_InputSerializable_ReturnsTrue_OutputStringMatches_OutputExceptionIsNotNull()
-        {
-            // Arrange
-            SomeClass input = new() { SomeProperty = 1 };
+        // Arrange
+        SomeClass input = new() { SomeProperty = 1 };
 
-            string expectedJson = "{\"someProperty\":1}";
+        string expectedJson = "{\"someProperty\":1}";
 
-            // Act
-            var result = input.TrySerializeCamelCase(out string outputString, out Exception outputException);
+        // Act
+        var result = input.TrySerializeCamelCase(out string outputString, out Exception outputException);
 
-            // Assert
-            result.Should().BeTrue();
-            outputString.Should().Be(expectedJson);
-            outputException.Should().BeNull();
-        }
+        // Assert
+        result.Should().BeTrue();
+        outputString.Should().Be(expectedJson);
+        outputException.Should().BeNull();
+    }
 
-        private class SomeClass
-        {
-            public int SomeProperty { get; set; }
-        }
+    private class SomeClass
+    {
+        public int SomeProperty { get; set; }
     }
 }


### PR DESCRIPTION
Move to .NET 6:
- increase packages versions to 2.0.0;
- update framework version;
- format code with `editorconfig` and `dotnet format` (use file-scoped namespaces);
- update dependencies' versions, and remove unused dependencies from projects.